### PR TITLE
Just patched bug which generates invalid blank environment variable strings.

### DIFF
--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -88,7 +88,7 @@ module Whenever
       
       output = []
       @env.each do |key, val|
-        output << "#{key}=#{val}\n"
+        output << "#{key}=#{val.blank? ? '""' : val}\n"
       end
       output << "\n"
       

--- a/test/functional/output_env_test.rb
+++ b/test/functional/output_env_test.rb
@@ -8,6 +8,8 @@ class OutputEnvTest < Test::Unit::TestCase
       <<-file
         env :MYVAR, 'blah'
         env 'MAILTO', "someone@example.com"
+        env :BLANKVAR, ''
+        env :NILVAR, nil
       file
     end
 
@@ -17,6 +19,14 @@ class OutputEnvTest < Test::Unit::TestCase
   
     should "output MAILTO environment variable" do
       assert_match "MAILTO=someone@example.com", @output
+    end
+
+    should "output BLANKVAR environment variable" do
+      assert_match "BLANKVAR=\"\"", @output
+    end
+
+    should "output NILVAR environment variable" do
+      assert_match "NILVAR=\"\"", @output
     end
   end
 


### PR DESCRIPTION
I tried to set my MAILTO variable blank like this:

env :MAILTO, ''

However, this generated the line 

MAILTO= 

which cron didn't accept. I've added two tests -- one for nil values and one for empty strings -- which patch this issue.

Cheers,

T.J.
