### PR TITLE
Undocumented change in lib/whenever/capistrano.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ For example, if you're using bundler do this:
     set :whenever_command, "bundle exec whenever"
     require "whenever/capistrano"
 
+If you are using different environments (such as staging, production), then you may want to do this:
+
+    set :whenever_environment, defer { stage }
+    require "whenever/capistrano"
+
+The capistrano variable `:stage` should be the one holding your environment name. This will make the correct `:environment` available in your schedule.rb.
+
 ### The `whenever` command
 
     $ cd /my/rails/app


### PR DESCRIPTION
Hi,

We were very startled when our staging environment suddenly began to execute jobs as if it was in production..

My configuration had something like this:
    set :whenever_command, defer { "bundle exec whenever --set environment=#{rails_env}" }
    require "whenever/capistrano"

And after we upgraded whenever, the actual command on staging became:
    bundle exec whenever --set environment=staging --update-crontab app_name --set environment=production
(which caused the actual value of `:environment` to be `production`)

My proposed patch adds an example similar to my updated configuration to the documentation.

~Amir
