### PR TITLE
Add quotes to --set example.

### DIFF
--- a/bin/whenever
+++ b/bin/whenever
@@ -20,7 +20,7 @@ OptionParser.new do |opts|
     options[:clear] = true
     options[:identifier] = identifier if identifier
   end
-  opts.on('-s', '--set [variables]', 'Example: --set environment=staging&path=/my/sweet/path') do |set|
+  opts.on('-s', '--set [variables]', 'Example: --set \'environment=staging&path=/my/sweet/path\'') do |set|
     options[:set] = set if set
   end
   opts.on('-f', '--load-file [schedule file]', 'Default: config/schedule.rb') do |file|


### PR DESCRIPTION
The arguments to --set should be quoted.  Adding this to the example might prevent silly mistakes.
