### PR TITLE
Run rake through bundle exec

### DIFF
--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -23,4 +23,8 @@ module Whenever
     File.exists?(File.join(path, 'script', 'rails'))
   end
 
+  def self.bundler?
+    File.exists?(File.join(path, 'Gemfile'))
+  end
+
 end

--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -8,7 +8,13 @@ set :path, Whenever.path
 set :job_template, "/bin/bash -l -c ':job'"
 
 job_type :command, ":task :output"
-job_type :rake,    "cd :path && RAILS_ENV=:environment rake :task --silent :output"
+
+# Run rake through bundler if possible
+if Whenever.bundler?
+  job_type :rake,    "cd :path && RAILS_ENV=:environment bundle exec rake :task --silent :output"
+else
+  job_type :rake,    "cd :path && RAILS_ENV=:environment rake :task --silent :output"
+end
 
 # Create a runner job that's appropriate for the Rails version,
 if Whenever.rails3?

--- a/test/functional/output_at_test.rb
+++ b/test/functional/output_at_test.rb
@@ -114,7 +114,7 @@ class OutputAtTest < Test::Unit::TestCase
     end
     
     should "output the rake task using one entry because the times are aligned" do
-      assert_match '2 5,15 * * 1,3,5 cd /your/path && RAILS_ENV=production rake blah:blah --silent', @output
+      assert_match '2 5,15 * * 1,3,5 cd /your/path && RAILS_ENV=production bundle exec rake blah:blah --silent', @output
     end
   end
   
@@ -177,7 +177,7 @@ class OutputAtTest < Test::Unit::TestCase
     end
     
     should "output all of the commands @daily" do
-      assert_match '@daily cd /your/path && RAILS_ENV=production rake blah:blah --silent', @output
+      assert_match '@daily cd /your/path && RAILS_ENV=production bundle exec rake blah:blah --silent', @output
       assert_match %(@daily cd /your/path && script/runner -e production 'runner_1'), @output
       assert_match '@daily command_1', @output
       assert_match %(@daily cd /your/path && script/runner -e production 'runner_2'), @output

--- a/test/functional/output_default_defined_jobs_test.rb
+++ b/test/functional/output_default_defined_jobs_test.rb
@@ -140,6 +140,24 @@ class OutputDefaultDefinedJobsTest < Test::Unit::TestCase
     end
     
     should "output the rake command using that path" do
+      assert_match two_hours + ' cd /my/path && RAILS_ENV=production bundle exec rake blahblah --silent', @output
+    end
+  end
+
+  context "A rake for a non-bundler app" do
+    setup do
+      Whenever.expects(:path).at_least_once.returns('/my/path')
+      Whenever.expects(:bundler?).returns(false)
+      @output = Whenever.cron \
+      <<-file
+        set :job_template, nil
+        every 2.hours do
+          rake 'blahblah'
+        end
+      file
+    end
+
+    should "not use invoke through bundler" do
       assert_match two_hours + ' cd /my/path && RAILS_ENV=production rake blahblah --silent', @output
     end
   end
@@ -157,7 +175,7 @@ class OutputDefaultDefinedJobsTest < Test::Unit::TestCase
     end
     
     should "output the rake command using that path" do
-      assert_match two_hours + ' cd /some/other/path && RAILS_ENV=production rake blahblah --silent', @output
+      assert_match two_hours + ' cd /some/other/path && RAILS_ENV=production bundle exec rake blahblah --silent', @output
     end
   end
   


### PR DESCRIPTION
When running rake you should always use version defined in Gemfile as it may be different to the one installed in system. 

This patch makes whenever use "bundle exec rake" instead of simply "rake" when there's a Gemfile present (which indicates use of bundler). Otherwise falls back to using system-wide "rake".
