### PR TITLE
Allow piping on cron from stdin to stdout

### DIFF
--- a/bin/whenever
+++ b/bin/whenever
@@ -33,9 +33,6 @@ OptionParser.new do |opts|
   opts.on('-k', '--cut [lines]', 'Cut lines from the top of the cronfile') do |lines|
     options[:cut] = lines.to_i if lines
   end
-  opts.on('-p', '--pipe', 'Pipe crontab from stdin, through whenever, and out to stdout') do
-    options[:pipe] = true
-  end
   opts.on('-v', '--version') { puts "Whenever v#{Whenever::VERSION}"; exit(0) }
 end.parse!
 

--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -59,7 +59,7 @@ module Whenever
       return @current_crontab if @current_crontab
 
       command_results = (
-        if @options[:pipe]
+        if !stdin.tty?
           stdin.read
         else
           command = ['crontab -l']
@@ -76,7 +76,7 @@ module Whenever
     
     def write_crontab(contents)
       target_fh = (
-        if @options[:pipe]
+        if !stdin.tty?
           stdout
         else
           File.open(Tempfile.new('whenever_tmp_cron').path, File::WRONLY | File::APPEND)
@@ -86,7 +86,7 @@ module Whenever
       target_fh << contents
       target_fh.close
 
-      if @options[:pipe]
+      if !stdin.tty?
         exit(0)
       else
         command = ['crontab']

--- a/test/functional/command_line_test.rb
+++ b/test/functional/command_line_test.rb
@@ -331,8 +331,10 @@ EXISTING_CRON
 
       @mock_stdout = StringIO.new
 
+      @mock_stdin.stubs(:tty?).returns(false)
+
       File.expects(:exists?).with('config/schedule.rb').returns(true)
-      @command = Whenever::CommandLine.new(:update => true, :identifier => 'My identifier', :pipe => true)
+      @command = Whenever::CommandLine.new(:update => true, :identifier => 'My identifier')
       @task = "#{two_hours} /my/command"
       Whenever.expects(:cron).returns(@task)
 


### PR DESCRIPTION
I have an unusual use case of Whenever where, on the server I work on, I'm not able to easily switch to a user account tasked with maintenance in order to manipulate its crontab. I am, however, able to modify its crontab through `sudo crontab -l` and `sudo crontab -`, giving me the ability to pipe its crontab through an intermediary process. I modified Whenever to allow this piping to occur through it when deploying through Capistrano, with a setup like this:

``` ruby
def whenever_wrap(flags)
  "#{sudo} crontab -l -u maintenance | bundle exec whenever --pipe #{flags} | #{sudo} crontab -u maintenance -"
end

set :whenever_command, ''
set(:whenever_update_flags) { whenever_wrap("--update-crontab #{fetch :whenever_identifier} --set environment=#{fetch :whenever_environment}") }
set(:whenever_clear_flags)  { whenever_wrap("--clear-crontab #{fetch :whenever_identifier}") }
```

The only real hacky thing to work around is the default cap tasks, otherwise using Whenever as a stdin processor is working quite nicely in our setup. Let me know if you need anything else added to this pull request.
