### PR TITLE
Moved chronic require to whenever/cron.rb, where it is actually used.

### DIFF
--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -1,4 +1,3 @@
-require 'chronic'
 require 'active_support/all'
 require 'thread'
 

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -1,3 +1,5 @@
+require 'chronic'
+
 module Whenever
   module Output
     class Cron


### PR DESCRIPTION
This makes it easier to track down which parts of whenever require what.
