### PR TITLE
Keep rake functional in absence of bundler.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,11 @@
-require 'bundler'
-Bundler::GemHelper.install_tasks
+begin
+  require 'bundler'
+rescue LoadError => e
+  warn("warning: Could not load bundler: #{e}")
+  warn("         Some rake tasks will not be defined")
+else
+  Bundler::GemHelper.install_tasks
+end
 
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|


### PR DESCRIPTION
Even without bundler it is possible to run the tests.

This change makes it so that rake does not completely die if bundler is missing.
