### PR TITLE
Compatibility with Rails < 2.3.11

### DIFF
--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -1,5 +1,5 @@
-require 'active_support/all'
 require 'thread'
+require 'active_support/all'
 
 module Whenever
   autoload :JobList,     'whenever/job_list'


### PR DESCRIPTION
Should actually close issue #132. Current version (0.7.0) still doesn't work with older Rails.
