### PR TITLE
added whenever_variables as a configuration variable

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -4,7 +4,8 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:whenever_command)      { "whenever" }
   _cset(:whenever_identifier)   { fetch :application }
   _cset(:whenever_environment)  { fetch :rails_env, "production" }
-  _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set environment=#{fetch :whenever_environment}" }
+  _cset(:whenever_variables)    { "environment=#{fetch :whenever_environment}" }
+  _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
   _cset(:whenever_clear_flags)  { "--clear-crontab #{fetch :whenever_identifier}" }
 
   # Disable cron jobs at the begining of a deploy.


### PR DESCRIPTION
I recently needed to set an additional variable via a cap task and found that the only way to do so was to override `whenever_update_flags` like so:

```
set :whenever_update_flags, defer { "--update-crontab #{fetch :whenever_identifier} --set 'environment=#{fetch :whenever_environment}&log_path=#{shared_path}'" }
```

This is a minor backwards compatible change that allows you to set the environment + variables independently:

```
set :whenever_variables, defer { "'environment=#{fetch :whenever_environment}&log_path=#{shared_path}'" }
```
