### PR TITLE
Escape % characters and raise exception on newline

### DIFF
--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -14,7 +14,11 @@ module Whenever
   
     def output
       job = process_template(@template, @options).strip
-      process_template(@job_template, { :job => job }).strip
+      out = process_template(@job_template, { :job => job }).strip
+      if out =~ /\n/
+        raise ArgumentError, "Task contains newline"
+      end
+      out.gsub(/%/, '\%')
     end
     
   protected

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -20,6 +20,32 @@ class JobTest < Test::Unit::TestCase
       Whenever.expects(:path).returns('/my/path')
       assert_equal '/my/path', new_job(:template => ':path').output
     end
+    
+    should "escape percent signs" do
+      job = new_job(
+        :template => "before :foo after",
+        :foo => "percent -> % <- percent"
+      )
+      assert_equal %q(before percent -> \% <- percent after), job.output
+    end
+    
+    should "assume percent signs are not already escaped" do
+      job = new_job(
+        :template => "before :foo after",
+        :foo => %q(percent preceded by a backslash -> \% <-)
+      )
+      assert_equal %q(before percent preceded by a backslash -> \\\% <- after), job.output
+    end
+    
+    should "reject newlines" do
+      job = new_job(
+        :template => "before :foo after",
+        :foo => "newline -> \n <- newline"
+      )
+      assert_raise ArgumentError do
+        job.output
+      end
+    end
   end
 
   


### PR DESCRIPTION
Percent signs need to be escaped, according to `man 5 crontab`:

> The  ``sixth'' field (the rest of the line) specifies the command to be
> run.  The entire command portion of the line, up  to  a  newline or  %
> character, will be executed by /bin/sh or by the shell specified in the
> SHELL variable of the crontab file.  Percent-signs (%) in the command,
> unless escaped with backslash (\), will be changed into newline charac‐
> ters, and all data after the first % will be sent  to  the command  as
> standard  input.  There  is  no way to split a single command line onto
> multiple lines, like the shell's trailing "\".

Since I do not have any better idea regarding newlines, I chose to raise an exception.
