### PR TITLE
Make default job types redirect any output from the 'cd' command to /dev/null

### DIFF
--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -11,14 +11,14 @@ job_type :command, ":task :output"
 
 # Run rake through bundler if possible
 if Whenever.bundler?
-  job_type :rake, "cd :path && RAILS_ENV=:environment bundle exec rake :task --silent :output"
+  job_type :rake, "cd :path > /dev/null && RAILS_ENV=:environment bundle exec rake :task --silent :output"
 else
-  job_type :rake, "cd :path && RAILS_ENV=:environment rake :task --silent :output"
+  job_type :rake, "cd :path > /dev/null && RAILS_ENV=:environment rake :task --silent :output"
 end
 
 # Create a runner job that's appropriate for the Rails version,
 if Whenever.rails3?
-  job_type :runner, "cd :path && script/rails runner -e :environment ':task' :output"
+  job_type :runner, "cd :path > /dev/null && script/rails runner -e :environment ':task' :output"
 else
-  job_type :runner, "cd :path && script/runner -e :environment ':task' :output"
+  job_type :runner, "cd :path > /dev/null && script/runner -e :environment ':task' :output"
 end


### PR DESCRIPTION
RVM wraps the `cd` command to detect `.rvmrc` files. When it finds one, it changes the ruby version and produces output like:

``` bash
Using /home/ndbroadbent/.rvm/gems/ruby-1.9.2-p290
```

This is undesirable for a cron task that is configured to send emails, because we would get emailed that one line every time, even when the task was successful. So this commit just silences the cd into the application directory, in case it contains an .rvmrc.

This is currently defined in our own `schedule.rb` file, but I thought it might be useful for others.
