### PR TITLE
Allowing manual overwrite of the `whenever_options` hash

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -29,7 +29,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       by setting the :whenever_update_flags variable. Additionally you can configure \
       which servers the crontab is updated on by setting the :whenever_roles variable.
     DESC
-    task :update_crontab do
+    task :update_crontab, :primary => true do
       options = fetch(:whenever_options)
 
       if find_servers(options).any?


### PR DESCRIPTION
This allows for further customization when deploying with capistrano. 

In my case I needed to only update the crontab on my primary db server, so overwriting the `whenever_options` hash like this, solved the problem:
- `set :whenever_options, { :roles => :db, :only => { :primary => true } }` will update the crontab only on the primary db server.
