### PR TITLE
Add :output to the new script job type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The default job types that ship with Whenever are defined like so:
 job_type :command, ":task :output"
 job_type :rake,    "cd :path && RAILS_ENV=:environment bundle exec rake :task --silent :output"
 job_type :runner,  "cd :path && script/rails runner -e :environment ':task' :output"
-job_type :script,  "cd :path && RAILS_ENV=:environment bundle exec script/:task"
+job_type :script,  "cd :path && RAILS_ENV=:environment bundle exec script/:task :output"
 ```
 
 Pre-Rails 3 apps and apps that don't use Bundler will redefine the `rake` and `runner` jobs respectively to function correctly.

--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -12,10 +12,10 @@ job_type :command, ":task :output"
 # Run rake through bundler if possible
 if Whenever.bundler?
   job_type :rake, "cd :path && RAILS_ENV=:environment bundle exec rake :task --silent :output"
-  job_type :script, "cd :path && RAILS_ENV=:environment bundle exec script/:task"
+  job_type :script, "cd :path && RAILS_ENV=:environment bundle exec script/:task :output"
 else
   job_type :rake, "cd :path && RAILS_ENV=:environment rake :task --silent :output"
-  job_type :script, "cd :path && RAILS_ENV=:environment script/:task"
+  job_type :script, "cd :path && RAILS_ENV=:environment script/:task :output"
 end
 
 # Create a runner job that's appropriate for the Rails version,


### PR DESCRIPTION
I added the `:output` variable to the new `script` job type.  This includes adding it to the README and adding tests for both `script` in general and specific to adding `:output`.
