### PR TITLE
evaluate setup and schedule invidually

### DIFF
--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -9,14 +9,16 @@ module Whenever
 
       pre_set(options[:set])
       
-      setup = File.read("#{File.expand_path(File.dirname(__FILE__))}/setup.rb")
+      setup_file = File.expand_path(File.dirname(__FILE__)).join('setup.rb')
+      setup = File.read(setup_file)
       schedule = if options[:string]
         options[:string]
       elsif options[:file]
         File.read(options[:file])
       end
       
-      instance_eval(setup + schedule, options[:file] || '<eval>')
+      instance_eval(setup, setup_file)
+      instance_eval(schedule, options[:file] || '<eval>')
     end
     
     def set(variable, value)


### PR DESCRIPTION
if there is an error in the schedule, the line numbers from the trace should not be offset by the number of lines in setup.rb
