### PR TITLE
run whenever from the release_path instead of the current_path in update_crontab task

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -32,11 +32,9 @@ Capistrano::Configuration.instance(:must_exist).load do
           else
             run "cd #{fetch :release_path} && #{fetch :whenever_command} #{fetch :whenever_clear_flags}", options
           end
-
-          run "cd #{fetch :release_path} && #{fetch :whenever_command} #{fetch :whenever_update_flags}#{role_arg}", options
         end
 
-        run "cd #{fetch :current_path} && #{fetch :whenever_command} #{fetch :whenever_update_flags}", options
+        run "cd #{fetch :release_path} && #{fetch :whenever_command} #{fetch :whenever_update_flags}", options
       end
     end
 


### PR DESCRIPTION
According to the capistrano docs: https://raw.github.com/mpasternacki/capistrano-documentation-support-files/master/default-execution-path/Capistrano%20Execution%20Path.jpg, deploy:finalize_update is run before deploy:symlink.

Whenever hooks its update_crontab task into the before deploy:finalize_update hook, which means the current_path will still point at the last successful deployment, not the one we're currently deploying. It should use current_path instead for this.
