### PR TITLE
fix file not found error when running under JRuby

### DIFF
--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -66,22 +66,23 @@ module Whenever
     end
     
     def write_crontab(contents)
-      tmp_cron_file = Tempfile.new('whenever_tmp_cron').path
-      File.open(tmp_cron_file, File::WRONLY | File::APPEND) do |file|
-        file << contents
-      end
+      tmp_cron_file = Tempfile.open('whenever_tmp_cron')
+      tmp_cron_file << contents
+      tmp_cron_file.fsync
 
       command = ['crontab']
       command << "-u #{@options[:user]}" if @options[:user]
-      command << tmp_cron_file
+      command << tmp_cron_file.path
 
       if system(command.join(' '))
         action = 'written' if @options[:write]
         action = 'updated' if @options[:update]
         puts "[write] crontab file #{action}"
+        tmp_cron_file.close!
         exit(0)
       else
         warn "[fail] Couldn't write crontab; try running `whenever' with no options to ensure your schedule file is valid."
+        tmp_cron_file.close!
         exit(1)
       end
     end


### PR DESCRIPTION
Tempfile deletes the file it creates after it's closed (for various definitions of "after"). It appears that this happens much sooner under JRuby (1.6.7.2) than under MRI. This was causing a race condition where running crontab /tmp/tempfile would often fail because JRuby had already unlinked the tempfile.

This pull request refactors the tempfile code to ensure that the file still exists when the crontab command is run, but still cleans it up before exiting.
