### PR TITLE
whenever clean previous cron settings, if you set several roles

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -27,7 +27,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       roles = [options[:roles]].flatten if options[:roles]
 
       if find_servers(options).any?
-        # make sure we go through the roles.each loop at least once
+        roles_arg = "" # empty for begin
         roles_arg = " --roles #{roles.join(",")}" unless roles.empty?
 
         on_rollback do


### PR DESCRIPTION
Example:

```
set :whenever_roles, [:app, :db]
```

By old capistrano task it update crontab with role app and when with role db. Last role crean all cron jobs (in my case all app role jobs clean). This help to fix this.
