### PR TITLE
 initial cap deploy with whenever fails

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -46,7 +46,7 @@ Capistrano::Configuration.instance(:must_exist).load do
             end
           end
 
-          run "cd #{fetch :current_path} && #{fetch :whenever_command} #{fetch :whenever_update_flags}#{role_arg}", options
+          run "cd #{fetch :latest_release} && #{fetch :whenever_command} #{fetch :whenever_update_flags}#{role_arg}", options
         end
       end
     end


### PR DESCRIPTION
`whenever` binary is not in the current_path bundle until after the `current` symlink has been updated.

as a result i see errors like this when for the first deploy (of a Rails app) after adding whenever

```
  * executing `deploy:restart'
    triggering before callbacks for `deploy:restart'
  * executing `whenever:update_crontab'
  * executing "cd /data/videometrics/current && bundle exec whenever --update-crontab videometrics_prod --set environment=prod"
    servers: ["server"]
    [server] executing command
*** [err :: server] /usr/local/rvm/gems/ruby-1.9.3-p0/gems/bundler-1.0.22/lib/bundler/rubygems_integration.rb:143:in `block in replace_gem': whenever is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
*** [err :: server] from /data/videometrics/shared/bundle/ruby/1.9.1/bin/whenever:18:in `<main>'
```

this was fixed for `cap whenever:clear_crontab` in https://github.com/javan/whenever/pull/204
but is still broken for `cap whenever:update_crontab`.
