### PR TITLE
Fixes #259 do not hardwire path of bash

### DIFF
--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -5,7 +5,16 @@ set :path, Whenever.path
 
 # All jobs are wrapped in this template.
 # http://blog.scoutapp.com/articles/2010/09/07/rvm-and-cron-in-production
-set :job_template, "/bin/bash -l -c ':job'"
+
+shell = "/bash"
+ENV['PATH'].split(':').each do |folder| 
+    if File.exists?(folder + shell) && File.executable?(folder + shell)
+        shell = folder + shell
+        break
+    end
+end
+
+set :job_template, shell + " -l -c ':job'"
 
 job_type :command, ":task :output"
 


### PR DESCRIPTION
Fixes #259 do not hardwire path of bash.

I sort of assume that whenever is specific for cron and therefore it isn't necessary to accomodate for Windows users is that correct?

R
