### PR TITLE
add support for multistage deployment via capistrano

### DIFF
--- a/bin/whenever
+++ b/bin/whenever
@@ -35,6 +35,9 @@ OptionParser.new do |opts|
   opts.on('-r', '--roles [role1,role2]', 'Comma-separated list of server roles to generate cron jobs for') do |roles|
     options[:roles] = roles.split(',').map(&:to_sym) if roles
   end
+  opts.on('-S', '--stage [stage]', 'Stage to generate cron jobs for') do |stage|
+    options[:stage] = stage.to_sym if stage
+  end
   opts.on('-v', '--version') { puts "Whenever v#{Whenever::VERSION}"; exit(0) }
 end.parse!
 

--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -1,6 +1,6 @@
 Capistrano::Configuration.instance(:must_exist).load do
   _cset(:whenever_roles)        { :db }
-  _cset(:whenever_options)      { {:roles => fetch(:whenever_roles)} }
+  _cset(:whenever_options)      { {:roles => fetch(:whenever_roles), :stage => fetch(:stage)} }
   _cset(:whenever_command)      { "whenever" }
   _cset(:whenever_identifier)   { fetch :application }
   _cset(:whenever_environment)  { fetch :rails_env, "production" }
@@ -25,6 +25,9 @@ Capistrano::Configuration.instance(:must_exist).load do
     task :update_crontab do
       options = fetch(:whenever_options)
       roles = [options[:roles]].flatten if options[:roles]
+      stage = options[:stage]
+
+      stage_arg = stage ? " --stage #{stage}" : ""
 
       if find_servers(options).any?
         # make sure we go through the roles.each loop at least once
@@ -40,13 +43,13 @@ Capistrano::Configuration.instance(:must_exist).load do
 
           on_rollback do
             if fetch :previous_release
-              run "cd #{fetch :previous_release} && #{fetch :whenever_command} #{fetch :whenever_update_flags}#{role_arg}", options
+              run "cd #{fetch :previous_release} && #{fetch :whenever_command} #{fetch :whenever_update_flags}#{role_arg}#{stage_arg}", options
             else
               run "cd #{fetch :release_path} && #{fetch :whenever_command} #{fetch :whenever_clear_flags}", options
             end
           end
 
-          run "cd #{fetch :latest_release} && #{fetch :whenever_command} #{fetch :whenever_update_flags}#{role_arg}", options
+          run "cd #{fetch :latest_release} && #{fetch :whenever_command} #{fetch :whenever_update_flags}#{role_arg}#{stage_arg}", options
         end
       end
     end

--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -2,7 +2,7 @@ require 'shellwords'
 
 module Whenever
   class Job
-    attr_reader :at, :roles
+    attr_reader :at, :roles, :stages
 
     def initialize(options = {})
       @options = options
@@ -10,6 +10,7 @@ module Whenever
       @template                = options.delete(:template)
       @job_template            = options.delete(:job_template) || ":job"
       @roles                   = Array.wrap(options.delete(:roles))
+      @stages                  = Array.wrap(options.delete(:stages))
       @options[:output]        = Whenever::Output::Redirection.new(options[:output]).to_s if options.has_key?(:output)
       @options[:environment] ||= :production
       @options[:path]          = Shellwords.shellescape(@options[:path] || Whenever.path)
@@ -26,6 +27,10 @@ module Whenever
 
     def has_role?(role)
       roles.empty? || roles.include?(role)
+    end
+
+    def has_stage?(stage)
+      stages.empty? || stages.include?(stage)
     end
 
   protected

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -1,6 +1,6 @@
 module Whenever
   class JobList
-    attr_reader :roles
+    attr_reader :roles, :stage
 
     def initialize(options)
       @jobs, @env, @set_variables, @pre_set_variables = {}, {}, {}, {}
@@ -12,6 +12,7 @@ module Whenever
       pre_set(options[:set])
 
       @roles = options[:roles] || []
+      @stage = options[:stage]
 
       setup_file = File.expand_path('../setup.rb', __FILE__)
       setup = File.read(setup_file)
@@ -131,12 +132,14 @@ module Whenever
       shortcut_jobs = []
       regular_jobs = []
 
-      output_all = roles.empty?
+      output_all_roles = roles.empty?
+      output_all_stages = stage.blank?
       @jobs.each do |time, jobs|
         jobs.each do |job|
-          next unless output_all || roles.any? do |r|
+          next unless output_all_roles || roles.any? do |r|
             job.has_role?(r)
           end
+          next unless output_all_stages || job.has_stage?(stage)
           Whenever::Output::Cron.output(time, job) do |cron|
             cron << "\n\n"
 
@@ -153,3 +156,4 @@ module Whenever
     end
   end
 end
+

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -16,6 +16,15 @@ class JobTest < Test::Unit::TestCase
       assert_equal false, new_job(:roles => 'bar').has_role?('foo')
     end
 
+    should "return the :stage set when #stages is called" do
+      assert_equal ['foo', 'bar'], new_job(:stages => ['foo', 'bar']).stages
+    end
+
+    should "return whether it has a stage from #has_stage?" do
+      assert new_job(:stages => 'foo').has_stage?('foo')
+      assert_equal false, new_job(:stages => 'bar').has_stage?('foo')
+    end
+
     should "substitute the :task when #output is called" do
       job = new_job(:template => ":task", :task => 'abc123')
       assert_equal 'abc123', job.output


### PR DESCRIPTION
This change allows to specify capistrano stage on which particular task can run in a manner similar to specifying capistrano roles. Likewise it is entirely optional.

The motivation behind this is that:
- a stage is not necessarily equivalent to Rails environment, thus more flexibility is allowed
- usage is more consistent with :roles than using solution described in the [wiki](https://github.com/javan/whenever/wiki/Setting-variables-on-the-fly)
- it defines a public API and does not force to rely on the knowledge of whenever internals
