### PR TITLE
Make sure roles are always an Array (empty if needed)

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -24,7 +24,7 @@ Capistrano::Configuration.instance(:must_exist).load do
     DESC
     task :update_crontab do
       options = fetch(:whenever_options)
-      roles = [options[:roles]].flatten if options[:roles]
+      roles = Array(options[:roles])
 
       if find_servers(options).any?
         # make sure we go through the roles.each loop at least once


### PR DESCRIPTION
Hi,

I've updated to Capistrano 2.13.5 and Whenever 0.8.0 and I can't deploy anymore.

I have this error : 

```
  * 2012-12-05 17:42:11 executing `whenever:update_crontab'
/Users/jlecour/.rbenv/versions/ree-1.8.7-2012.02/gemsets/dbadmin/gems/whenever-0.8.0/lib/whenever/capistrano/recipes.rb:31: undefined method `empty?' for nil:NilClass (NoMethodError)
```

In my deploy recipe, I have this : 

```
set(:whenever_options) { {:except => { :pra => true }} }
set :whenever_command, "bundle exec whenever"
require "whenever/capistrano"
```

My whenever options are like this to prevent writing to the crontab on servers that have the `pra` flag to `true` : 

```
server "main.example.com", :app, :web, :db, :primary => true
server "backup.example.com", :app, :web, :pra => true
```

It works if I amend my whenever options like this : 

```
set(:whenever_options) { {:roles => [:app], :except => { :pra => true }} }
```

Looking at the code (https://github.com/javan/whenever/blob/master/lib/whenever/capistrano/recipes.rb#L27) it's clear that the `roles` variable is set only if `options[:roles]` is not `nil` and then the `#empty?` method is called on `nil`.

I've tried to force `options[:roles]` to be an `Array` with `Array()` and all the tests still pass.
