### PR TITLE
Change when you want to run the "update_crontab:whenever"

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -2,7 +2,7 @@ require "whenever/capistrano/recipes"
 
 Capistrano::Configuration.instance(:must_exist).load do
   # Write the new cron jobs near the end.
-  before "deploy:finalize_update", "whenever:update_crontab"
+  after "deploy:create_symlink", "whenever:update_crontab"
   # If anything goes wrong, undo.
   after "deploy:rollback", "whenever:update_crontab"
 end


### PR DESCRIPTION
Fixes #271, #269

`whenever update_crontab` is executed, before the `bundle install` is executed, `bundler: command not found: whenever` error.
Therefore, I have changed the timing of the execution.

Sorry, I am not good at English. 
