### PR TITLE
Fix #229 - Don't interpolate attributes with no corresponding balue

### DIFF
--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -33,7 +33,7 @@ module Whenever
     def process_template(template, options)
       template.gsub(/:\w+/) do |key|
         before_and_after = [$`[-1..-1], $'[0..0]]
-        option = options[key.sub(':', '').to_sym]
+        option = options[key.sub(':', '').to_sym] || key
 
         if before_and_after.all? { |c| c == "'" }
           escape_single_quotes(option)

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -30,6 +30,10 @@ class JobTest < Test::Unit::TestCase
       assert_equal '/my/path', new_job(:template => ':path').output
     end
 
+    should "not substitute parameters for which no value is set" do
+      assert_equal 'Hello :world', new_job(:template => ':matching :world', :matching => 'Hello').output
+    end
+
     should "escape the :path" do
       assert_equal '/my/spacey\ path', new_job(:template => ':path', :path => '/my/spacey path').output
     end


### PR DESCRIPTION
This should remove issues with ports and non-attributes strings containing a colon in job templates.

This fixes https://github.com/javan/whenever/issues/229.
