### PR TITLE
use latest_release path in update_crontab

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -18,7 +18,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       args = {
         :command => fetch(:whenever_command),
         :flags   => fetch(:whenever_update_flags),
-        :path    => fetch(:release_path)
+        :path    => fetch(:latest_release)
       }
 
       if whenever_servers.any?
@@ -30,6 +30,7 @@ Capistrano::Configuration.instance(:must_exist).load do
             args[:path] = fetch(:previous_release)
           else
             # clear the crontab if no previous release
+            args[:path]  = fetch(:release_path)
             args[:flags] = fetch(:whenever_clear_flags)
           end
 


### PR DESCRIPTION
This should fix the timeout issue encountered by some in 0.8.1. This reverts to using latest_release as the path for update_crontab cap tasks. This change was inadvertent to begin with, so reverting it back is a good thing.

This addresses issue #288, but doesn't fully fix it.
