### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ It's a little bit dated now, but remains a good introduction.
 
 ----
 
-Compatible with Ruby 1.8.7-1.9.3, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
+Compatible with Ruby 1.8.7-1.9.3, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/javan/whenever)
 
 ----
 


### PR DESCRIPTION
Hello,

Just wanted to drop you a note to let you know that Whenever has been added to Code Climate. Code Climate is a service I built that provides code quality metrics for Ruby apps and libraries, and is free for OSS. You can view the data for Whenever here:

https://codeclimate.com/github/javan/whenever

This is a small pull request that adds a Code Climate badge to the README, in case you want this information to be available to contributors, like RSpec does:

https://github.com/rspec/rspec-rails#readme

Let me know if you have any questions! Hope you find it useful.

Cheers,

-Bryan
