### PR TITLE
Run update_crontab in after deploy:finalize_update

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -2,7 +2,7 @@ require "whenever/capistrano/recipes"
 
 Capistrano::Configuration.instance(:must_exist).load do
   # Write the new cron jobs near the end.
-  before "deploy:finalize_update", "whenever:update_crontab"
+  after "deploy:finalize_update", "whenever:update_crontab"
   # If anything goes wrong, undo.
   after "deploy:rollback", "whenever:update_crontab"
 end


### PR DESCRIPTION
Running the hook before deploy:finalize_update means its run after the code has been updated, but BEFORE bundle has been ran - resulting in "bundle exec whenever" failing with command not found. The correct way would seem to run it in the after hook for the same operation, which happens AFTER the gems have been bundled.
