### PR TITLE
Makes sure capistrano cd's to the right directory when executing a deploy:rollback

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -22,6 +22,17 @@ Capistrano::Configuration.instance(:must_exist).load do
       }
 
       if whenever_servers.any?
+        if task_call_frames[0].task.fully_qualified_name == 'deploy:rollback'
+          if fetch(:previous_release)
+            # rollback to the previous release's crontab
+            args[:path] = fetch(:previous_release)
+          else
+            # clear the crontab if no previous release
+            args[:path]  = fetch(:release_path)
+            args[:flags] = fetch(:whenever_clear_flags)
+          end
+        end
+
         whenever_run_commands(args)
 
         on_rollback do


### PR DESCRIPTION
Right now, if you would manually execute a `cap deploy:rollback`, it would result in a failure because of the whenever recipe. It would try to `cd` into the wrong directory: `latest_release` instead of `previous_release`.

The `on_rollback` block inside the recipe is only called when another recipe fails and the current changes have to be rolled back. It isn't called when you manually invoke a rollback.

There is some duplication in the code which might be cleaned up.
