### PR TITLE
Allow times in seconds by chaining together tasks prefixed with multiple sleep commands

### DIFF
--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -3,6 +3,7 @@ require 'shellwords'
 module Whenever
   class Job
     attr_reader :at, :roles
+    attr_accessor :options
 
     def initialize(options = {})
       @options = options


### PR DESCRIPTION
Here's a way to support commands that need to run very frequently. If the time is less than a minute, it multiplies the task and prefixes each group with different `sleep` durations.

For example, 

``` ruby
every 10.seconds do
  command 'echo "running frequent command"'
end
```

produces:

```
* * * * * /bin/bash -l -c '(echo "running frequent command") & 
(sleep 10 && echo "running frequent command") & 
(sleep 20 && echo "running frequent command") & 
(sleep 30 && echo "running frequent command") & 
(sleep 40 && echo "running frequent command") & 
(sleep 50 && echo "running frequent command")'
```

(all on one line.)

Just an idea, but I found it to be pretty useful.
