### PR TITLE
Update lib/whenever/capistrano.rb

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -2,7 +2,7 @@ require "whenever/capistrano/recipes"
 
 Capistrano::Configuration.instance(:must_exist).load do
   # Write the new cron jobs near the end.
-  before "deploy:finalize_update", "whenever:update_crontab"
+  after "deploy:finalize_update", "whenever:update_crontab"
   # If anything goes wrong, undo.
   after "deploy:rollback", "whenever:update_crontab"
 end


### PR DESCRIPTION
Makes whenever run _after_ bundler finishes its install
this could be related to #305
