### PR TITLE
quote :application in capistrano task

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -9,8 +9,8 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:whenever_identifier)   { fetch :application }
   _cset(:whenever_environment)  { fetch :rails_env, "production" }
   _cset(:whenever_variables)    { "environment=#{fetch :whenever_environment}" }
-  _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
-  _cset(:whenever_clear_flags)  { "--clear-crontab #{fetch :whenever_identifier}" }
+  _cset(:whenever_update_flags) { %Q{--update-crontab "#{fetch :whenever_identifier}" --set #{fetch :whenever_variables}} }
+  _cset(:whenever_clear_flags)  { %Q{--clear-crontab "#{fetch :whenever_identifier}"} }
 
   namespace :whenever do
     desc "Update application's crontab entries using Whenever"


### PR DESCRIPTION
whenever passes the :application variable from the capistrano deploy script to its command line as follows:

``` ruby
--update-crontab application_name
```

But in the case that the application variable contains a space, its not treated as a single string but as a further argument. This causes the application name in the crontab to just the string before the first space.
