### PR TITLE
Makes sure capistrano cd's to the right directory when executing a deploy:rollback

### DIFF
--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -22,29 +22,11 @@ Capistrano::Configuration.instance(:must_exist).load do
       }
 
       if whenever_servers.any?
-        if task_call_frames[0].task.fully_qualified_name == 'deploy:rollback'
-          if fetch(:previous_release)
-            # rollback to the previous release's crontab
-            args[:path] = fetch(:previous_release)
-          else
-            # clear the crontab if no previous release
-            args[:path]  = fetch(:release_path)
-            args[:flags] = fetch(:whenever_clear_flags)
-          end
-        end
-
+        args = whenever_prepare_for_rollback(args) if task_call_frames[0].task.fully_qualified_name == 'deploy:rollback'
         whenever_run_commands(args)
 
         on_rollback do
-          if fetch(:previous_release)
-            # rollback to the previous release's crontab
-            args[:path] = fetch(:previous_release)
-          else
-            # clear the crontab if no previous release
-            args[:path]  = fetch(:release_path)
-            args[:flags] = fetch(:whenever_clear_flags)
-          end
-
+          args = whenever_prepare_for_rollback(args)
           whenever_run_commands(args)
         end
       end

--- a/lib/whenever/capistrano/support.rb
+++ b/lib/whenever/capistrano/support.rb
@@ -22,6 +22,18 @@ module Whenever
           end
         end
 
+        def whenever_prepare_for_rollback args
+          if fetch(:previous_release)
+            # rollback to the previous release's crontab
+            args[:path] = fetch(:previous_release)
+          else
+            # clear the crontab if no previous release
+            args[:path]  = fetch(:release_path)
+            args[:flags] = fetch(:whenever_clear_flags)
+          end
+          args
+        end
+
         def whenever_run_commands(args)
           unless [:command, :path, :flags].all? { |a| args.include?(a) }
             raise ArgumentError, ":command, :path, & :flags are required"

--- a/test/unit/capistrano_support_test.rb
+++ b/test/unit/capistrano_support_test.rb
@@ -78,6 +78,22 @@ class CapistranoSupportTest < Test::Unit::TestCase
       end
     end
 
+    context "#whenever_prepare_for_rollback" do
+      should "set path to previous_release if there is a previous release" do
+        args = {}
+        @capistrano.stubs(:fetch).with(:previous_release).returns("/some/path/20121221010000")
+        assert_equal({:path => "/some/path/20121221010000"}, @capistrano.whenever_prepare_for_rollback(args))
+      end
+
+      should "set path to release_path and flags to whenever_clear_flags if there is no previous release" do
+        args = {}
+        @capistrano.stubs(:fetch).with(:previous_release).returns(nil)
+        @capistrano.stubs(:fetch).with(:release_path).returns("/some/path/20121221010000")
+        @capistrano.stubs(:fetch).with(:whenever_clear_flags).returns("--clear-crontab whenever_identifier")
+        assert_equal({:path => "/some/path/20121221010000", :flags => "--clear-crontab whenever_identifier"}, @capistrano.whenever_prepare_for_rollback(args))
+      end
+    end
+
     context "#whenever_run_commands" do
       should "require :command arg" do
         assert_raise ArgumentError do


### PR DESCRIPTION
This is an update of #300 where the args for rollback are abstracted into the capistrano support lib.
Though, I'm not 100% happy with this code since it moves arguments logic into the helper where I think it should be in the recipe itself. What do you think?
