### PR TITLE
Default to use `/bin/sh`

### DIFF
--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -5,7 +5,7 @@ set :path, Whenever.path
 
 # All jobs are wrapped in this template.
 # http://blog.scoutapp.com/articles/2010/09/07/rvm-and-cron-in-production
-set :job_template, "/bin/bash -l -c ':job'"
+set :job_template, "/bin/sh -l -c ':job'"
 
 job_type :command, ":task :output"
 

--- a/test/functional/output_default_defined_jobs_test.rb
+++ b/test/functional/output_default_defined_jobs_test.rb
@@ -31,7 +31,7 @@ class OutputDefaultDefinedJobsTest < Test::Unit::TestCase
     end
 
     should "output the command with the default job template" do
-      assert_match /^.+ .+ .+ .+ \/bin\/bash -l -c 'blahblah'$/, @output
+      assert_match /^.+ .+ .+ .+ \/bin\/sh -l -c 'blahblah'$/, @output
     end
   end
 
@@ -39,16 +39,16 @@ class OutputDefaultDefinedJobsTest < Test::Unit::TestCase
     setup do
       @output = Whenever.cron \
       <<-file
-        set :job_template, "/bin/bash -l -c ':job'"
+        set :job_template, "/bin/sh -l -c ':job'"
         every 2.hours do
-          command "blahblah", :job_template => "/bin/sh -l -c ':job'"
+          command "blahblah", :job_template => "/usr/bin/env bash -l -c ':job'"
         end
       file
     end
 
     should "output the command using that job_template" do
-      assert_match /^.+ .+ .+ .+ \/bin\/sh -l -c 'blahblah'$/, @output
-      assert_no_match /bash/, @output
+      assert_match /^.+ .+ .+ .+ \/usr\/bin\/env bash -l -c 'blahblah'$/, @output
+      assert_no_match /\/bin\/sh/, @output
     end
   end
 

--- a/test/functional/output_jobs_for_roles_test.rb
+++ b/test/functional/output_jobs_for_roles_test.rb
@@ -12,7 +12,7 @@ class OutputJobsForRolesTest < Test::Unit::TestCase
     end
 
     should "output the cron job" do
-      assert_equal two_hours + " /bin/bash -l -c 'blahblah'\n\n", @output
+      assert_equal two_hours + " /bin/sh -l -c 'blahblah'\n\n", @output
     end
   end
 
@@ -28,7 +28,7 @@ class OutputJobsForRolesTest < Test::Unit::TestCase
 
     # this should output the job because not specifying a role means "all roles"
     should "output the cron job" do
-      assert_equal two_hours + " /bin/bash -l -c 'blahblah'\n\n", @output
+      assert_equal two_hours + " /bin/sh -l -c 'blahblah'\n\n", @output
     end
   end
 
@@ -44,7 +44,7 @@ class OutputJobsForRolesTest < Test::Unit::TestCase
 
     # this should output the job because not requesting roles means "all roles"
     should "output the cron job" do
-      assert_equal two_hours + " /bin/bash -l -c 'blahblah'\n\n", @output
+      assert_equal two_hours + " /bin/sh -l -c 'blahblah'\n\n", @output
     end
   end
 
@@ -78,7 +78,7 @@ class OutputJobsForRolesTest < Test::Unit::TestCase
     end
 
     should "output both jobs" do
-      assert_equal two_hours + " /bin/bash -l -c 'role1_cmd'\n\n0 * * * * /bin/bash -l -c 'role2_cmd'\n\n", @output
+      assert_equal two_hours + " /bin/sh -l -c 'role1_cmd'\n\n0 * * * * /bin/sh -l -c 'role2_cmd'\n\n", @output
     end
   end
 end


### PR DESCRIPTION
There is no guarantee that `bash(1)` is installed on a system and if it
is, it can be in another location than `/bin/bash`.  If `bash(1)` has to be
installed, it should be looked after using:

```
/usr/bin/env bash
```

Otherwise, it is possible to use `/bin/sh` (which is often `bash(1)` on a
GNU/Linux system) instead of `/bin/bash`.  This is what this patch does.
It also fix the regression tests accordingly and update them to use
`bash(1)` (looking for it using `env(1)`) instead of `sh(1)` in the test
overriding job_template.

This way, whenever can be used out of the box on systems installing
`bash(1)` in other locations than `/bin`.
