### PR TITLE
update crontab later in capistrano lifecycle

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -2,7 +2,7 @@ require "whenever/capistrano/recipes"
 
 Capistrano::Configuration.instance(:must_exist).load do
   # Write the new cron jobs near the end.
-  before "deploy:finalize_update", "whenever:update_crontab"
+  after "deploy:finalize_update", "whenever:update_crontab"
   # If anything goes wrong, undo.
   after "deploy:rollback", "whenever:update_crontab"
 end


### PR DESCRIPTION
with capistrano 2.13.5, before 'finalize_update' runs before bundler, leading to "command not found: whenever"
