### PR TITLE
Allow more complex job types

### DIFF
--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -44,7 +44,7 @@ module Whenever
       yield
     end
 
-    def job_type(name, template)
+    def job_type(name, template = nil, &block)
       class_eval do
         define_method(name) do |task, *args|
           options = { :task => task, :template => template }
@@ -56,7 +56,7 @@ module Whenever
           options[:output] = @output if defined?(@output) && !options.has_key?(:output)
 
           @jobs[@current_time_scope] ||= []
-          @jobs[@current_time_scope] << Whenever::Job.new(@options.merge(@set_variables).merge(options))
+          @jobs[@current_time_scope] << Whenever::Job.new(@options.merge(@set_variables).merge(options), &block)
         end
       end
     end


### PR DESCRIPTION
Allow more complex job types by allowing blocks to be passed to `job_type` resp. `Whenever::Job.new`.

I came up with this because I needed to run multiple rake tasks in order and only if the previous command exited successfully. This would be possible with my PR:

``` ruby
job_type :chained_rake do |options|
  if options[:task] && !options[:task].empty?
    taskcmds = options[:task].map { |task| "bundle exec rake #{task} :output" }
    "cd :path && export RAILS_ENV=:environment && " << taskcmds.join(" && ")
  end
end

every 1.day, at: "5:00 am" do
  chained_rake [
    "bt:wvoip",
    "invoices:create",
    "invoices:pdf",
    "invoices:export",
    "invoices:export_deliver",
  ]
end
```

What do you think?
