### PR TITLE
by waiting till later, we prevent rake from not being found

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -2,7 +2,7 @@ require "whenever/capistrano/recipes"
 
 Capistrano::Configuration.instance(:must_exist).load do
   # Write the new cron jobs near the end.
-  before "deploy:finalize_update", "whenever:update_crontab"
+  before "deploy", "whenever:update_crontab"
   # If anything goes wrong, undo.
   after "deploy:rollback", "whenever:update_crontab"
 end


### PR DESCRIPTION
without this rake is sometimes not found

https://www.google.com/search?q=whenever%2Fcapistrano+rake+not+found&aq=f&oq=whenever%2Fcapistrano+rake+not+found&aqs=chrome.0.57j58j62.5960j0&sourceid=chrome&ie=UTF-8
