### PR TITLE
Use deploy:create_symlink instead of deploy:finalize_update

### DIFF
--- a/lib/whenever/capistrano.rb
+++ b/lib/whenever/capistrano.rb
@@ -2,7 +2,7 @@ require "whenever/capistrano/recipes"
 
 Capistrano::Configuration.instance(:must_exist).load do
   # Write the new cron jobs near the end.
-  before "deploy:finalize_update", "whenever:update_crontab"
+  before "deploy:create_symlink", "whenever:update_crontab"
   # If anything goes wrong, undo.
   after "deploy:rollback", "whenever:update_crontab"
 end


### PR DESCRIPTION
I think it is better to run `crontab` after symlink updated code to `/path/to/current` is better.

When I run deploy:update_code, I don't want crontab to be rewrited. (because the updated code is not a current one)
