### PR TITLE
remove support for ruby1.8, and add support for ruby2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 rvm:
+  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - ree
   - jruby
+  - jruby-18mode
   - jruby-19mode

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ It's a little bit dated now, but remains a good introduction.
 
 ----
 
-Compatible with Ruby 1.9.2-2.0.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
+Compatible with Ruby 1.8.7-2.0.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
 
 ----
 

--- a/whenever.gemspec
+++ b/whenever.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chronic", ">= 0.6.3"
   s.add_dependency "activesupport", ">= 2.3.4"
 
+  s.add_development_dependency "shoulda-matchers", "2.0.0"
   s.add_development_dependency "shoulda", ">= 2.1.1"
   s.add_development_dependency "mocha", ">= 0.9.5"
   s.add_development_dependency "rake"


### PR DESCRIPTION
This gem is dependent on 'shoulda-matchers' gem, and shoulda-matchers is now incompatible with ruby1.8.
So, currently travis tests for whenever is failing, because bundler throws Gem::InstallError while installing shoulda-matchers in ruby1.8.7 environment.

This commit remove ruby1.8 support from .travis.yml and README.md.

Also, I added ruby2.0 support in README.md. (.travis.yml already includes ruby2.0 support)
