### PR TITLE
accept a lambda to produce output redirection config/string

### DIFF
--- a/lib/whenever/output_redirection.rb
+++ b/lib/whenever/output_redirection.rb
@@ -11,6 +11,7 @@ module Whenever
           when String   then redirect_from_string
           when Hash     then redirect_from_hash
           when NilClass then ">> /dev/null 2>&1"
+          when Proc     then @output.call
           else ''
         end 
       end

--- a/test/functional/output_redirection_test.rb
+++ b/test/functional/output_redirection_test.rb
@@ -304,4 +304,23 @@ class OutputRedirectionTest < Test::Unit::TestCase
       assert_match /^.+ .+ .+ .+ blahblah >> cron.log 2>&1$/, @output
     end
   end
+
+
+  context "A command when the standard output is set to a lambda" do
+    setup do
+      @output = Whenever.cron \
+      <<-file
+        set :job_template, nil
+        set :output, lambda { "2>&1 | logger -t whenever_cron" }
+        every 2.hours do
+          command "blahblah"
+        end
+      file
+    end
+
+    should "output the command by result of the lambda evaluated" do
+      assert_match /^.+ .+ .+ .+ blahblah 2>&1 | logger -t whenever_cron$/, @output
+    end
+  end
+
 end


### PR DESCRIPTION
This is designed for customize default output in schedule.rb, an example is using it to redirect output to syslog: 
set :output, lambda { "2>&1 | logger -t whenever_cron" }
