### PR TITLE
use script/rails runner with rails 4

### DIFF
--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -23,6 +23,10 @@ module Whenever
     File.exists?(File.join(path, 'script', 'rails'))
   end
 
+  def self.rails4?
+    File.exists?(File.join(path, 'bin', 'rails'))
+  end
+
   def self.bundler?
     File.exists?(File.join(path, 'Gemfile'))
   end

--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -21,7 +21,7 @@ else
 end
 
 # Create a runner job that's appropriate for the Rails version,
-if Whenever.rails3?
+if Whenever.rails3? || Whenever.rails4?
   job_type :runner, "cd :path && script/rails runner -e :environment ':task' :output"
 else
   job_type :runner, "cd :path && script/runner -e :environment ':task' :output"


### PR DESCRIPTION
Rails 4 uses Rails.root/bin/rails which makes whenever spit out a bad cron job. Specifically script/runner ..

I don't think there are any other issues with whenever and Rails 4.
