### PR TITLE
Add a capistrano option to use sudo/rvmsudo as another user

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ set :whenever_identifier, defer { "#{application}_#{stage}" }
 require "whenever/capistrano"
 ```
 
+If you want to specify a different cron user than the deployment user, you can do like this:
+
+```ruby
+set :whenever_sudo_as, 'cron_user'
+require "whenever/capistrano"
+```
+It executes the command as 'cron_user' with sudo.
+If you are using rvm, adding this line might be helpful, too.
+
+```ruby
+set :whenever_sudo, 'rvmsudo'
+```
+
 ### Capistrano roles
 
 The first thing to know about the new roles support is that it is entirely

--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -11,6 +11,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:whenever_variables)    { "environment=#{fetch :whenever_environment}" }
   _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
   _cset(:whenever_clear_flags)  { "--clear-crontab #{fetch :whenever_identifier}" }
+  _cset(:whenever_sudo)         { "sudo" }
 
   namespace :whenever do
     desc "Update application's crontab entries using Whenever"

--- a/lib/whenever/capistrano/support.rb
+++ b/lib/whenever/capistrano/support.rb
@@ -41,8 +41,9 @@ module Whenever
 
           whenever_server_roles.each do |server, roles|
             roles_arg = roles.empty? ? "" : " --roles #{roles.join(',')}"
-
-            command = "cd #{args[:path]} && #{args[:command]} #{args[:flags]}#{roles_arg}"
+            command = "cd #{args[:path]} && "
+            command += "#{fetch(:whenever_sudo)} -p 'sudo password: ' -u #{fetch(:whenever_sudo_as)} " if exists? :whenever_sudo_as
+            command += "#{args[:command]} #{args[:flags]}#{roles_arg}"
             run command, whenever_options.merge(:hosts => server)
           end
         end


### PR DESCRIPTION
Sometimes a deployment user has to be different from cron job user.
I added a capistrano option "whenever_sudo_as" in order to set up cron jobs as a different user for such cases.
