### PR TITLE
Allow to add more set variables via :whenever_extra_variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Allow the :job_template system to reprocess using the parameters provided so
   that the :job_template can refer to job-specific parameters. [Austin Ziegler]
 
+* Allow to add extra set variables for capistrano via `:whenever_extra_variables` variable [Trung Lê]
 
 ### 0.8.4 / July 22, 2012
 

--- a/lib/whenever/capistrano/recipes.rb
+++ b/lib/whenever/capistrano/recipes.rb
@@ -8,8 +8,8 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:whenever_command)      { "whenever" }
   _cset(:whenever_identifier)   { fetch :application }
   _cset(:whenever_environment)  { fetch :rails_env, "production" }
-  _cset(:whenever_variables)    { "environment=#{fetch :whenever_environment}" }
-  _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
+  _cset(:whenever_variables)    { whenever_variables({ environment: fetch(:whenever_environment) }.merge(fetch(:whenever_extra_variables, {}))) }
+  _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set '#{fetch :whenever_variables}'" }
   _cset(:whenever_clear_flags)  { "--clear-crontab #{fetch :whenever_identifier}" }
 
   namespace :whenever do

--- a/lib/whenever/capistrano/support.rb
+++ b/lib/whenever/capistrano/support.rb
@@ -22,6 +22,10 @@ module Whenever
           end
         end
 
+        def whenever_variables(hash)
+          hash.map { |k, v| "#{k}=#{v}" }.join('&')
+        end
+
         def whenever_prepare_for_rollback args
           if fetch(:previous_release)
             # rollback to the previous release's crontab


### PR DESCRIPTION
This patch allows user to customise the `--set` variables within their deploy script.
