### PR TITLE
Added 'minutes' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ every 3.hours do
   command "/usr/bin/my_great_command"
 end
 
+every 5.minutes do
+  command "/usr/bin/my_great_command"
+end
+
 every 1.day, :at => '4:30 am' do
   runner "MyModel.task_to_run_at_four_thirty_in_the_morning"
 end


### PR DESCRIPTION
I'm new to Ruby and was not familiar with the core extensions introduced by ActiveSupport - so I wasn't sure if using 'minutes' would work or not. This would make it clear to new users.
