### PR TITLE
added whenever_command_environment_variables option to capistrano v3 options

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -5,7 +5,9 @@ namespace :whenever do
     on roles fetch(:whenever_roles) do |host|
       args = args + Array(yield(host)) if block_given?
       within release_path do
-        execute :whenever, *args
+        with fetch(:whenever_command_environment_variables) do
+          execute :whenever, *args
+        end
       end
     end
   end
@@ -31,6 +33,7 @@ namespace :load do
   task :defaults do
     set :whenever_roles,        ->{ :db }
     set :whenever_command,      ->{ "bundle exec whenever" }
+    set :whenever_command_environment_variables, ->{ {} }
     set :whenever_identifier,   ->{ fetch :application }
     set :whenever_environment,  ->{ fetch :rails_env, "production" }
     set :whenever_variables,    ->{ "environment=#{fetch :whenever_environment}" }


### PR DESCRIPTION
I need to pass some environment variables to whenever when I update the crontab.  These are basically custom variables, which I cannot pass as command-line arguments.

I tried what is described in [Capistrano V3 Integration](https://github.com/javan/whenever/#capistrano-v3-integration) in the README: 

```
SSHKit.config.command_map[:whenever] = "bundle exec whenever"
```

However, it didn't work the way I needed it to.  This PR is a more elegant, reliable solution.
