### PR TITLE
Added Ruby 2.1.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ree
   - jruby
   - jruby-18mode

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ It's a little bit dated now, but remains a good introduction.
 
 ----
 
-Compatible with Ruby 1.8.7-2.0.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
+Compatible with Ruby 1.8.7-2.1.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
 
 ----
 


### PR DESCRIPTION
tests pass

```
Run options: 

# Running tests:

Finished tests in 0.656838s, 336.4604 tests/s, 733.8187 assertions/s.           
221 tests, 482 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.1.0p0 (2013-12-25 revision 44422) [x86_64-darwin12.0]
```
