### PR TITLE
Fix capistrano integration with multiple whenever_roles

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -2,7 +2,7 @@ namespace :whenever do
   def setup_whenever_task(*args, &block)
     args = Array(fetch(:whenever_command)) + args
 
-    on roles fetch(:whenever_roles) do |host|
+    on roles *fetch(:whenever_roles) do |host|
       host_args = Array(yield(host))
       within release_path do
         with fetch(:whenever_command_environment_variables) do


### PR DESCRIPTION
Deploy fails without splatting the array of whenever_roles since capistrano tries to call to_sym on what is already an array.

```
NoMethodError: undefined method `to_sym' for [:app, :db]:Array
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:26:in `each'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:26:in `flat_map'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:26:in `required'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:15:in `roles'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:11:in `for'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration/servers.rb:45:in `fetch_roles'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration/servers.rb:18:in `roles_for'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/configuration.rb:45:in `roles_for'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/capistrano-3.0.1/lib/capistrano/dsl/env.rb:43:in `roles'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/whenever-0.9.2/lib/whenever/tasks/whenever.rake:5:in `setup_whenever_task'
/Users/mrhaddad/.rvm/gems/ruby-2.1.1@mb-web/gems/whenever-0.9.2/lib/whenever/tasks/whenever.rake:17:in `block (2 levels) in <top (required)>'
```
