### PR TITLE
Skip whenever tasks earlier if no hosts matched

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -3,6 +3,11 @@ namespace :whenever do
     args = Array(fetch(:whenever_command)) + args
 
     on roles fetch(:whenever_roles) do |host|
+      unless host
+        warn "No matching hosts for whenever tasks."
+        break
+      end
+
       host_args = Array(yield(host))
       within release_path do
         with fetch(:whenever_command_environment_variables) do


### PR DESCRIPTION
Addresses #445

Basically skips whenever tasks when there's no matching hosts.
