### PR TITLE
updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ In your "Capfile" file:
 require "whenever/capistrano"
 ```
 
-Take a look at the load:defaults (bottom of file) task for options you can set. <http://github.com/javan/whenever/blob/master/lib/whenever/tasks/whenever.rake>. For example, to namespace the crontab entries by application and stage do this.
+Take a look at the load:defaults (bottom of file) task for options you can set. <https://github.com/javan/whenever/blob/master/lib/whenever/capistrano/v3/tasks/whenever.rake>. For example, to namespace the crontab entries by application and stage do this.
 
 ```ruby
 set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }


### PR DESCRIPTION
The README references the Cap v3 tasks file, but that file must have moved since that part of the README was written. I updated the link.
