### PR TITLE
Fixed task :clear_crontab

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -22,7 +22,10 @@ namespace :whenever do
 
   desc "Clear application's crontab entries using Whenever"
   task :clear_crontab do
-    setup_whenever_task(fetch(:whenever_clear_flags))
+    setup_whenever_task do |host|
+      roles = host.roles_array.join(",")
+      [fetch(:whenever_clear_flags),  "--roles=#{roles}"]
+    end
   end
 
   after "deploy:updated",  "whenever:update_crontab"


### PR DESCRIPTION
Task fails with error:
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing on host example.com: Exception while executing on host example.com: no block given (yield)
/home/ekho/.gem/ruby/1.9.1/gems/whenever-0.9.2/lib/whenever/tasks/whenever.rake:11:in `block in setup_whenever_task'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `instance_exec'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `run'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/runners/parallel.rb:13:in `block (2 levels) in execute'
SSHKit::Runner::ExecuteError: Exception while executing on host example.com: no block given (yield)
/home/ekho/.gem/ruby/1.9.1/gems/whenever-0.9.2/lib/whenever/tasks/whenever.rake:11:in `block in setup_whenever_task'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `instance_exec'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `run'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/runners/parallel.rb:13:in `block (2 levels) in execute'
LocalJumpError: no block given (yield)
/home/ekho/.gem/ruby/1.9.1/gems/whenever-0.9.2/lib/whenever/tasks/whenever.rake:11:in `block in setup_whenever_task'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `instance_exec'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/backends/netssh.rb:54:in `run'
/home/ekho/.gem/ruby/1.9.1/gems/sshkit-1.5.1/lib/sshkit/runners/parallel.rb:13:in `block (2 levels) in execute'
