### PR TITLE
fix time problems for ActiveSupport versions greater than 4.1.6

### DIFF
--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -83,22 +83,22 @@ module Whenever
 
       def parse_time
         timing = Array.new(5, '*')
-        case @time
-          when 0.seconds...1.minute
+        case @time.value
+          when 0.seconds.value...1.minute.value
             raise ArgumentError, "Time must be in minutes or higher"
-          when 1.minute...1.hour
+          when 1.minute.value...1.hour.value
             minute_frequency = @time / 60
             timing[0] = comma_separated_timing(minute_frequency, 59, @at || 0)
-          when 1.hour...1.day
+          when 1.hour.value...1.day.value
             hour_frequency = (@time / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min : @at
             timing[1] = comma_separated_timing(hour_frequency, 23)
-          when 1.day...1.month
+          when 1.day.value...1.month.value
             day_frequency = (@time / 24 / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min  : 0
             timing[1] = @at.is_a?(Time) ? @at.hour : @at
             timing[2] = comma_separated_timing(day_frequency, 31, 1)
-          when 1.month..12.months
+          when 1.month.value..12.months.value
             month_frequency = (@time / 30  / 24 / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min  : 0
             timing[1] = @at.is_a?(Time) ? @at.hour : 0


### PR DESCRIPTION
Hi @javan , 

First off, thanks for an awesome gem!

Ran in to this problem today using ActiveSupport 4.2.0.beta2 in a new project ( was confused that whenever was working fine on all of my other projects, initially thought it was down to choosing ruby 2.2.0.preview1 over 2.1.3 but finally traced it down to the switch from ActiveSupport 4.1.6 to ActiveSupport 4.2.0.beta2 ) and applied this fix locally and it worked great for all of my crontab generation. Also tested it on ActiveSupport < 4.2.0.beta1 and it worked for me on the versions I tested (4.1.6, 4.0.0, 3.2.19). 
