### PR TITLE
If `whenever_environment` is not set, and neither is `rails_env` go for capistrano stage before defaulting to production

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -35,7 +35,7 @@ namespace :load do
     set :whenever_command,      ->{ [:bundle, :exec, :whenever] }
     set :whenever_command_environment_variables, ->{ {} }
     set :whenever_identifier,   ->{ fetch :application }
-    set :whenever_environment,  ->{ fetch :rails_env, "production" }
+    set :whenever_environment,  ->{ fetch :rails_env, fetch(:stage, "production") }
     set :whenever_variables,    ->{ "environment=#{fetch :whenever_environment}" }
     set :whenever_update_flags, ->{ "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
     set :whenever_clear_flags,  ->{ "--clear-crontab #{fetch :whenever_identifier}" }


### PR DESCRIPTION
Most people should use capistrano stage names which mirror their environment names
PR for https://github.com/javan/whenever/issues/485
