### PR TITLE
using 2 separate local variables for cap3 deployment args so that roles don't overwrite each other's arguments

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -3,10 +3,10 @@ namespace :whenever do
     args = Array(fetch(:whenever_command)) + args
 
     on roles fetch(:whenever_roles) do |host|
-      args = args + Array(yield(host)) if block_given?
+      _args = args + Array(yield(host)) if block_given?
       within release_path do
         with fetch(:whenever_command_environment_variables) do
-          execute *args
+          execute *_args
         end
       end
     end


### PR DESCRIPTION
Given the following config/schedule.rb:

```
every :day, :roles => [:app] do
  command 'touch this'
end

every :day, :roles => [:db] do
  command 'touch that'
end
```

When I deploy with Capistrano 3, the arguments passed to `whenever --update_crontab` get mixed together because a single variable is being used for each:

```
DEBUG[78e9452b] Command: cd /my/path/current && ( rvm default do bundle exec whenever --update-crontab MY_CRONTAB --set output=/my/path/shared/log/log.log --roles=app --update-crontab MY_CRONTAB --set output=/my/path/shared/log/log.log --roles=db )
DEBUG[f7255f02] Command: cd /my/path/current && ( rvm default do bundle exec whenever --update-crontab MY_CRONTAB --set output=/my/path/shared/log/log.log --roles=app --update-crontab MY_CRONTAB --set output=/my/path/shared/log/log.log --roles=db )
```

This PR fixes that by adding an additional local variable
