### PR TITLE
Fixed duplicated and mixed deployment args when have 2+ different roles.

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -3,10 +3,11 @@ namespace :whenever do
     args = Array(fetch(:whenever_command)) + args
 
     on roles fetch(:whenever_roles) do |host|
-      args = args + Array(yield(host)) if block_given?
+      _args = args
+      _args += Array(yield(host)) if block_given?
       within release_path do
         with fetch(:whenever_command_environment_variables) do
-          execute *args
+          execute *_args
         end
       end
     end


### PR DESCRIPTION
Confirmed #493 

And more flexiable fixing.
