### PR TITLE
Tighten up the cron regex

### DIFF
--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -4,7 +4,7 @@ module Whenever
   module Output
     class Cron
       KEYWORDS = [:reboot, :yearly, :annually, :monthly, :weekly, :daily, :midnight, :hourly]
-      REGEX = /^(@(#{KEYWORDS.join '|'})|.+\s+.+\s+.+\s+.+\s+.+.?)$/
+      REGEX = /^(@(#{KEYWORDS.join '|'})|(([\d\/,\-]+|\*)\s*){5})$/
 
       attr_accessor :time, :task
 
@@ -44,7 +44,7 @@ module Whenever
 
       def time_in_cron_syntax
         case @time
-          when REGEX  then @time # raw cron sytax given
+          when REGEX  then @time # raw cron syntax given
           when Symbol then parse_symbol
           when String then parse_as_string
           else parse_time

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -11,7 +11,7 @@ class CronTest < Whenever::TestCase
     end
   end
 
-  # For santity, do some tests on straight String
+  # For sanity, do some tests on straight cron-syntax strings
   should "parse correctly" do
     assert_equal '* * * * *', parse_time(Whenever.seconds(1, :minute))
     assert_equal '0,5,10,15,20,25,30,35,40,45,50,55 * * * *', parse_time(Whenever.seconds(5, :minutes))
@@ -214,6 +214,18 @@ class CronParseShortcutsTest < Whenever::TestCase
 end
 
 class CronParseRawTest < Whenever::TestCase
+  should "raise if cron-syntax string is too long" do
+    assert_raises ArgumentError do
+      parse_time('* * * * * *')
+    end
+  end
+
+  should "raise if cron-syntax string is invalid" do
+    assert_raises ArgumentError do
+      parse_time('** * * * *')
+    end
+  end
+
   should "return the same cron sytax" do
     crons = ['0 0 27-31 * *', '* * * * *', '2/3 1,9,22 11-26 1-6 *',
              "*\t*\t*\t*\t*",


### PR DESCRIPTION
The old regex would allow cron-style strings such as '\* \* \* \* \* \* \* *', which is
invalid. While it's very difficult, if not impossible, to regex a cron-style string
this should be a significant improvement.

It allows exactly 5 occurances of: any integer, comma, forward-slash or dash more than
once OR a single *.
