### PR TITLE
On cron write fail ask the user to check the output is valid cron syntax

### DIFF
--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -82,7 +82,7 @@ module Whenever
         puts "[write] crontab file #{action}"
         exit(0)
       else
-        warn "[fail] Couldn't write crontab; try running `whenever' with no options to ensure your schedule file is valid."
+        warn "[fail] Couldn't write crontab; try running `whenever' with no options to ensure your schedule file is valid, be sure to check the output for valid cron syntax"
         exit(1)
       end
     end


### PR DESCRIPTION
The old error message asks users to try running `whenever` without
arguments to ensure the schedule file is valid. If this fails then the
user can look in their schedule file for an error. But what if running a
plain `whenever` succeeds? This updated message acknowledges
that a successful run of `whenever` does not mean the schedule file 
is valid and asks them to check the _output_ is syntactically valid and
does not contain errors.
