### PR TITLE
added classes for redirecting output to commands

### DIFF
--- a/lib/whenever/output_redirection.rb
+++ b/lib/whenever/output_redirection.rb
@@ -1,23 +1,69 @@
 module Whenever
   module Output
+    class Command
+      def to_s(command)
+        " >( #{command} ) "
+      end
+    end
+
+    class MailCommand < Command
+      attr_reader :subject, :from, :to
+      def initialize(options={})
+        raise ArgumentError, "MailCommand must have a subject" unless options[:subject]
+        raise ArgumentError, "MailCommand must have a from" unless options[:from]
+        raise ArgumentError, "MailCommand must have a to" unless options[:to]
+
+        @subject = "-s \"#{options[:subject]}\""
+        @from = "-r \"#{options[:from]}\""
+        @to = options[:to].is_a?(Array) ? options[:to].join(' ') : options[:to]
+      end
+
+      def to_s
+        super("mail -E #{subject} #{from} #{to}")
+      end
+    end
+
+    class LoggerCommand < Command
+      attr_reader :tag
+      def initialize(options)
+        raise ArgumentError, "LoggerCommand must have a tag" unless options[:tag]
+        @tag = options[:tag]
+      end
+
+      def to_s
+        super("logger -t #{tag}")
+      end
+    end
+
+    class TeeCommand < Command
+      attr_reader :commands
+      def initialize(*commands)
+        @commands = commands
+      end
+
+      def to_s
+        super("tee #{commands.join(' ')} > /dev/null")
+      end
+    end
+
     class Redirection
       def initialize(output)
         @output = output
       end
-      
+
       def to_s
         return '' unless defined?(@output)
         case @output
-          when String   then redirect_from_string
-          when Hash     then redirect_from_hash
-          when NilClass then ">> /dev/null 2>&1"
-          when Proc     then @output.call
+          when Command, String  then redirect_from_string
+          when Hash             then redirect_from_hash
+          when NilClass         then ">> /dev/null 2>&1"
+          when Proc             then @output.call
           else ''
-        end 
+        end
       end
-      
+
     protected
-      
+
       def stdout
         return unless @output.has_key?(:standard)
         @output[:standard].nil? ? '/dev/null' : @output[:standard]


### PR DESCRIPTION
This PR provides an abstraction layer for redirecting output to shell commands.

A common use of this that I continue to encounter is where I want to receive an email of standard error.
Another use that an existing unit test implies is common is redirecting output to the logger command.
I even included a convenient way to do both, using the shell command `tee`.

If you merge this PR, I will update https://github.com/javan/whenever/wiki/Output-redirection-aka-logging-your-cron-jobs with clear instructions on how to use this new feature.  In the mean time, the test I wrote should be a pretty clear example.
