### PR TITLE
Remove identifier from comment_base

### DIFF
--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -120,7 +120,7 @@ module Whenever
     end
 
     def comment_base
-      "Whenever generated tasks for: #{@options[:identifier]}"
+      "Whenever generated tasks"
     end
 
     def comment_open


### PR DESCRIPTION
Said identifier causes problems if a machine is accessed via multiple hostnames/addresses/etc., since whenever appears to create a new block of jobs in `crontab` for each hostname or address that's used to access the machine.  This causes duplication of jobs run (which causes problems with things like backup archive creation, since now there are two different jobs competing for the exact same resources to do the exact same thing).

This might be a bit heavy-handed, however.
