### PR TITLE
Fixed #479, updated scheduling for :year

### DIFF
--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -12,7 +12,7 @@ module Whenever
         @at_given = at
         @time = @time_given = time
         @task = task
-        @at   = at.is_a?(String) ? (Chronic.parse(at, {guess: :begin}) || 0) : (at || 0)
+        @at   = at.is_a?(String) ? (Chronic.parse(at, {:guess => :begin}) || 0) : (at || 0)
       end
 
       def self.enumerate(item, detect_cron = true)

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -10,9 +10,9 @@ module Whenever
 
       def initialize(time = nil, task = nil, at = nil)
         @at_given = at
-        @time = time
+        @time = @time_given = time
         @task = task
-        @at   = at.is_a?(String) ? (Chronic.parse(at) || 0) : (at || 0)
+        @at   = at.is_a?(String) ? (Chronic.parse(at, {guess: :begin}) || 0) : (at || 0)
       end
 
       def self.enumerate(item, detect_cron = true)
@@ -107,7 +107,9 @@ module Whenever
             else
               @at.zero? ? 1 : @at
             end
-            timing[3] = comma_separated_timing(month_frequency, 12, 1)
+            timing[3] = @time_given.eql?(:year) ? 
+              (@at.is_a?(Time) ? @at.month : 1) : 
+              comma_separated_timing(month_frequency, 12, 1)
           else
             return parse_as_string
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,12 @@ module Whenever::TestHelpers
       cron = parse_time(Whenever.seconds(2, :hours), 'some task', time)
       assert_equal expected, cron.split(' ')[0]
     end
+
+    def assert_years_and_days_and_hours_and_minutes_equals(expected, time)
+      cron = parse_time(:year, 'some task', time)
+      minutes, hours, days, month, *garbage = cron.split(' ')
+      assert_equal expected, [month, days, hours, minutes]
+    end
 end
 
 Whenever::TestCase.send(:include, Whenever::TestHelpers)

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -140,6 +140,22 @@ class CronParseMonthsTest < Whenever::TestCase
   end
 end
 
+class CronParseYearsTest < Whenever::TestCase
+  should "parse correctly when given an 'at' with year's days, hours, minutes as a Time" do
+    # first param is an array with [month, days, hours, minutes]
+    assert_years_and_days_and_hours_and_minutes_equals %w(1 1 0 0),  'year'
+    assert_years_and_days_and_hours_and_minutes_equals %w(7 14 0 0),  'July 14th'
+    assert_years_and_days_and_hours_and_minutes_equals %w(2 11 23 0), 'Feb 11 11PM'
+    assert_years_and_days_and_hours_and_minutes_equals %w(4 23 0 0), 'april 22nd at midnight' # looks like midnight means the next day
+  end
+
+  should "parse correctly when given an 'at' with days as an Integer" do
+    # first param is an array with [days, hours, minutes]
+    assert_years_and_days_and_hours_and_minutes_equals %w(1 1 0 0),  1
+    assert_years_and_days_and_hours_and_minutes_equals %w(1 17 0 0), 17
+  end
+end
+
 class CronParseDaysOfWeekTest < Whenever::TestCase
   should "parse days of the week correctly" do
     {
@@ -194,7 +210,7 @@ class CronParseShortcutsTest < Whenever::TestCase
     assert_equal '0 0 1 * *',  parse_time(:month)
     assert_equal '0 0 * * *',  parse_time(:day)
     assert_equal '0 * * * *',  parse_time(:hour)
-    assert_equal '0 0 1 12 *', parse_time(:year)
+    assert_equal '0 0 1 1 *', parse_time(:year)
     assert_equal '0 0 1,8,15,22 * *', parse_time(:week)
   end
 


### PR DESCRIPTION
" every :year, at: 'July 24th' " was considering
- month as December by default
- time was considered as 12:00

Updated code in way that it should consider
- month (if provided) or should set January as default instead of December
- default time should be beginning of the day
