### PR TITLE
Put load:defaults inside whenever's namespace

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -27,17 +27,18 @@ namespace :whenever do
 
   after "deploy:updated",  "whenever:update_crontab"
   after "deploy:reverted", "whenever:update_crontab"
-end
 
-namespace :load do
-  task :defaults do
-    set :whenever_roles,        ->{ :db }
-    set :whenever_command,      ->{ [:bundle, :exec, :whenever] }
-    set :whenever_command_environment_variables, ->{ {} }
-    set :whenever_identifier,   ->{ fetch :application }
-    set :whenever_environment,  ->{ fetch :rails_env, fetch(:stage, "production") }
-    set :whenever_variables,    ->{ "environment=#{fetch :whenever_environment}" }
-    set :whenever_update_flags, ->{ "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
-    set :whenever_clear_flags,  ->{ "--clear-crontab #{fetch :whenever_identifier}" }
+  namespace :load do
+    task :defaults do
+      set :whenever_roles,        ->{ :db }
+      set :whenever_command,      ->{ [:bundle, :exec, :whenever] }
+      set :whenever_command_environment_variables, ->{ {} }
+      set :whenever_identifier,   ->{ fetch :application }
+      set :whenever_environment,  ->{ fetch :rails_env, fetch(:stage, "production") }
+      set :whenever_variables,    ->{ "environment=#{fetch :whenever_environment}" }
+      set :whenever_update_flags, ->{ "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
+      set :whenever_clear_flags,  ->{ "--clear-crontab #{fetch :whenever_identifier}" }
+    end
   end
+  after "load:defaults", "whenever:load:defaults"
 end


### PR DESCRIPTION
I'm not familiar enough with rake, but my bet is something changed on rake (10.4.2) which prevents tasks with the same name from being ran.

Since capistrano already has a 'load:defaults' task, the one provided by whenever is never run.