### PR TITLE
don't crash on non-existing roles

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -3,6 +3,7 @@ namespace :whenever do
     args = Array(fetch(:whenever_command)) + args
 
     on roles fetch(:whenever_roles) do |host|
+      next if host.nil?
       args_for_host = block_given? ? args + Array(yield(host)) : args
       within release_path do
         with fetch(:whenever_command_environment_variables) do


### PR DESCRIPTION
When a non-existing role is used for as :whenever_roles, the variable `host` on line 5 in whenever.rake can be nil.

To reproduce, define :whenever_roles as:

`set :whenever_roles, -> { :dummy }`