### PR TITLE
Ruby 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
   - ree
   - jruby
   - jruby-18mode

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ It's a little bit dated now, but remains a good introduction.
 
 ----
 
-Compatible with Ruby 1.8.7-2.1.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
+Compatible with Ruby 1.8.7-2.2.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
 
 ----
 

--- a/whenever.gemspec
+++ b/whenever.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "mocha", ">= 0.9.5"
   s.add_development_dependency "rake"
+  s.add_development_dependency "minitest"
 end


### PR DESCRIPTION
We are using whenever with Ruby MRI 2.2.0 for a while on production apps without any problems. More importantly, all tests passes on 2.2.0. I updated README and Travis config.

Had to add minitest as a development dependency because it is out of the Ruby stdlib now (https://bugs.ruby-lang.org/issues/9711).