### PR TITLE
Make crontab command customizable

### DIFF
--- a/bin/whenever
+++ b/bin/whenever
@@ -35,6 +35,9 @@ OptionParser.new do |opts|
   opts.on('-r', '--roles [role1,role2]', 'Comma-separated list of server roles to generate cron jobs for') do |roles|
     options[:roles] = roles.split(',').map(&:to_sym) if roles
   end
+  opts.on('-x', '--crontab-command [command]', 'Default: crontab') do |crontab_command|
+    options[:crontab_command] = crontab_command if crontab_command
+  end
   opts.on('-v', '--version') { puts "Whenever v#{Whenever::VERSION}"; exit(0) }
 end.parse!
 

--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -9,9 +9,10 @@ module Whenever
     def initialize(options={})
       @options = options
 
-      @options[:file]       ||= 'config/schedule.rb'
-      @options[:cut]        ||= 0
-      @options[:identifier] ||= default_identifier
+      @options[:crontab_command] ||= 'crontab'
+      @options[:file]            ||= 'config/schedule.rb'
+      @options[:cut]             ||= 0
+      @options[:identifier]      ||= default_identifier
 
       if !File.exists?(@options[:file]) && @options[:clear].nil?
         warn("[fail] Can't find file: #{@options[:file]}")
@@ -57,7 +58,8 @@ module Whenever
     def read_crontab
       return @current_crontab if @current_crontab
 
-      command = ['crontab -l']
+      command = [@options[:crontab_command]]
+      command << '-l'
       command << "-u #{@options[:user]}" if @options[:user]
 
       command_results  = %x[#{command.join(' ')} 2> /dev/null]
@@ -65,7 +67,7 @@ module Whenever
     end
 
     def write_crontab(contents)
-      command = ['crontab']
+      command = [@options[:crontab_command]]
       command << "-u #{@options[:user]}" if @options[:user]
       command << "-"
 


### PR DESCRIPTION
To be able to update the correct crontab on my deploy server I like to be able to replace the crontab command with `sudo -u some-cronuser /usr/bin/crontab`. This PR adds the cli option `--crontab-command` which does just that. The default `crontab` command is unchanged.
