### PR TITLE
Allow equals signs in values that are set on the fly

### DIFF
--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -89,7 +89,7 @@ module Whenever
       pairs = variable_string.split('&')
       pairs.each do |pair|
         next unless pair.index('=')
-        variable, value = *pair.split('=')
+        variable, value = *pair.split('=', 2)
         unless variable.nil? || variable == "" || value.nil? || value == ""
           variable = variable.strip.to_sym
           set(variable, value.strip)

--- a/test/functional/command_line_test.rb
+++ b/test/functional/command_line_test.rb
@@ -329,3 +329,19 @@ EXISTING_CRON
     assert_equal existing, @command.send(:prepare, existing)
   end
 end
+
+class PreservingEqualsInSetValuesTest < Whenever::TestCase
+  setup do
+    @output = Whenever.cron :set => 'password=ABC=123&user=admin', :string => \
+    <<-file
+      job_type :my_job, 'USER=:user PASSWORD=:password'
+      every 2.hours do
+        my_job 'foobar'
+      end
+    file
+  end
+
+  should "preserve any equals signs that occur in set values" do
+    assert_match "USER=admin PASSWORD=ABC=123", @output
+  end
+end


### PR DESCRIPTION
The current code strips everything after the first equals sign in the value of a variable set on the fly. For example, `whenever --set 'a=b=c&d=e'` will set a to 'b' and d to 'e'. I noticed this when trying to pass a base64-encoded value that had trailing equals signs which were all stripped off.

This patch fixes this stripping by interpreting everything after the first equals sign in a key-value pair as the value.