### PR TITLE
Patch to support solaris/smartos

### DIFF
--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -4,6 +4,7 @@ require 'whenever/job'
 require 'whenever/command_line'
 require 'whenever/cron'
 require 'whenever/output_redirection'
+require 'whenever/os'
 
 module Whenever
   def self.cron(options)

--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'whenever/os'
 
 module Whenever
   class CommandLine
@@ -57,6 +58,7 @@ module Whenever
     def read_crontab
       return @current_crontab if @current_crontab
 
+
       command = ['crontab -l']
       command << "-u #{@options[:user]}" if @options[:user]
 
@@ -67,7 +69,8 @@ module Whenever
     def write_crontab(contents)
       command = ['crontab']
       command << "-u #{@options[:user]}" if @options[:user]
-      command << "-"
+      # Solaris/SmartOS cron does not support the - option to read from stdin.
+      command << "-" unless OS.solaris?
 
       IO.popen(command.join(' '), 'r+') do |crontab|
         crontab.write(contents)

--- a/lib/whenever/os.rb
+++ b/lib/whenever/os.rb
@@ -1,0 +1,11 @@
+module Whenever
+    module OS
+      def OS.solaris?
+        (/solaris/ =~ RUBY_PLATFORM)
+      end
+
+      def OS.smartos?
+        OS.solaris?
+      end
+    end
+end


### PR DESCRIPTION
- Solaris/Smartos cron does not support the "-" option to read from stdin.