### PR TITLE
Default environment to `:stage` in Capistrano v2

### DIFF
--- a/lib/whenever/capistrano/v2/recipes.rb
+++ b/lib/whenever/capistrano/v2/recipes.rb
@@ -7,7 +7,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:whenever_options)      { {:roles => fetch(:whenever_roles)} }
   _cset(:whenever_command)      { "whenever" }
   _cset(:whenever_identifier)   { fetch :application }
-  _cset(:whenever_environment)  { fetch :rails_env, "production" }
+  _cset(:whenever_environment)  { fetch :rails_env, fetch(:stage, "production") }
   _cset(:whenever_variables)    { "environment=#{fetch :whenever_environment}" }
   _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
   _cset(:whenever_clear_flags)  { "--clear-crontab #{fetch :whenever_identifier}" }


### PR DESCRIPTION
Similar to #492, but for Cap v2: if `:rails_env` is not set, try and fetch `:stage`, and fallback to "production".