### PR TITLE
fixbug: cron regexp for with step expression

### DIFF
--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -4,7 +4,7 @@ module Whenever
   module Output
     class Cron
       KEYWORDS = [:reboot, :yearly, :annually, :monthly, :weekly, :daily, :midnight, :hourly]
-      REGEX = /^(@(#{KEYWORDS.join '|'})|(([\d\/,\-]+|\*)\s*){5})$/
+      REGEX = /^(@(#{KEYWORDS.join '|'})|(([\d\/,\-]+|\*|\*\/\d+)\s*){5})$/
 
       attr_accessor :time, :task
 

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -228,7 +228,7 @@ class CronParseRawTest < Whenever::TestCase
 
   should "return the same cron sytax" do
     crons = ['0 0 27-31 * *', '* * * * *', '2/3 1,9,22 11-26 1-6 *',
-             "*\t*\t*\t*\t*",
+             "*\t*\t*\t*\t*", '*/12 * * * *',
              '@reboot', '@yearly', '@annually', '@monthly', '@weekly',
              '@daily', '@midnight', '@hourly']
     crons.each do |cron|


### PR DESCRIPTION
The old regexp would not allow step expression such as '*/2 * * * *', but it is valid cron expression.
New regexp will allow it.