### PR TITLE
adding feature: changing MAILTO per job 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ If you want to change `MAILTO` per jobs, you can specify as below ways.
 
 ```ruby
 every 3.hours do
-  command "/usr/bin/my_super_command", mailto: 'my_super_command_output@example.com'
+  command "/usr/bin/my_super_command", :mailto => 'my_super_command_output@example.com'
 end
 ```
 
 or
 
 ```ruby
-every 3.hours, mailto: 'my_super_command@example.com'  do
+every 3.hours, :mailto => 'my_super_command_output@example.com'  do
   command "/usr/bin/my_super_command"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -96,6 +96,36 @@ Or set the job_template to nil to have your jobs execute normally.
 set :job_template, nil
 ```
 
+### Customize `MAILTO` environment variable
+
+You can specify `MAILTO` environment variable, which is recipient address of the email that contains output from the jobs.
+
+For example:
+
+```ruby
+env 'MAILTO', 'output_of_cron@example.com'
+
+every 3.hours do
+  command "/usr/bin/my_great_command"
+end
+```
+
+If you want to change `MAILTO` per jobs, you can specify as below ways.
+
+```ruby
+every 3.hours do
+  command "/usr/bin/my_super_command", mailto: 'my_super_command_output@example.com'
+end
+```
+
+or
+
+```ruby
+every 3.hours, mailto: 'my_super_command@example.com'  do
+  command "/usr/bin/my_super_command"
+end
+```
+
 ### Capistrano integration
 
 Use the built-in Capistrano recipe for easy crontab updates with deploys. For Capistrano V3, see the next section.

--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -2,12 +2,13 @@ require 'shellwords'
 
 module Whenever
   class Job
-    attr_reader :at, :roles
+    attr_reader :at, :roles, :mailto
 
     def initialize(options = {})
       @options = options
       @at                               = options.delete(:at)
       @template                         = options.delete(:template)
+      @mailto                           = options.fetch(:mailto, :default_mailto)
       @job_template                     = options.delete(:job_template) || ":job"
       @roles                            = Array(options.delete(:roles))
       @options[:output]                 = options.has_key?(:output) ? Whenever::Output::Redirection.new(options[:output]).to_s : ''

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -50,13 +50,16 @@ module Whenever
           options = { :task => task, :template => template }
           options.merge!(args[0]) if args[0].is_a? Hash
 
+          options[:mailto] ||= @options.fetch(:mailto, :default_mailto)
+
           # :cron_log was an old option for output redirection, it remains for backwards compatibility
           options[:output] = (options[:cron_log] || @cron_log) if defined?(@cron_log) || options.has_key?(:cron_log)
           # :output is the newer, more flexible option.
           options[:output] = @output if defined?(@output) && !options.has_key?(:output)
 
-          @jobs[@current_time_scope] ||= []
-          @jobs[@current_time_scope] << Whenever::Job.new(@options.merge(@set_variables).merge(options))
+          @jobs[options.fetch(:mailto)] ||= {}
+          @jobs[options.fetch(:mailto)][@current_time_scope] ||= []
+          @jobs[options.fetch(:mailto)][@current_time_scope] << Whenever::Job.new(@options.merge(@set_variables).merge(options))
         end
       end
     end
@@ -136,31 +139,51 @@ module Whenever
       entries.map { |entry| entry.join(' ') }
     end
 
-    def cron_jobs
-      return if @jobs.empty?
+    def cron_jobs_of_time(time, jobs)
+      shortcut_jobs, regular_jobs = [], []
 
-      shortcut_jobs = []
-      regular_jobs = []
+      jobs.each do |job|
+        next unless roles.empty? || roles.any? do |r|
+          job.has_role?(r)
+        end
+        Whenever::Output::Cron.output(time, job) do |cron|
+          cron << "\n\n"
 
-      output_all = roles.empty?
-      @jobs.each do |time, jobs|
-        jobs.each do |job|
-          next unless output_all || roles.any? do |r|
-            job.has_role?(r)
-          end
-          Whenever::Output::Cron.output(time, job) do |cron|
-            cron << "\n\n"
-
-            if cron[0,1] == "@"
-              shortcut_jobs << cron
-            else
-              regular_jobs << cron
-            end
+          if cron[0,1] == "@"
+            shortcut_jobs << cron
+          else
+            regular_jobs << cron
           end
         end
       end
 
       shortcut_jobs.join + combine(regular_jobs).join
+    end
+
+    def cron_jobs
+      return if @jobs.empty?
+
+      output = []
+
+      # jobs with default mailto's must be output before the ones with non-default mailto's.
+      @jobs.delete(:default_mailto) { Hash.new }.each do |time, jobs|
+        output << cron_jobs_of_time(time, jobs)
+      end
+
+      @jobs.each do |mailto, time_and_jobs|
+        output_jobs = []
+
+        time_and_jobs.each do |time, jobs|
+          output_jobs << cron_jobs_of_time(time, jobs)
+        end
+
+        output_jobs.reject! { |output_job| output_job.empty? }
+
+        output << "MAILTO=#{mailto}\n\n" unless output_jobs.empty?
+        output << output_jobs
+      end
+
+      output.join
     end
   end
 end

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -170,7 +170,7 @@ module Whenever
         output << cron_jobs_of_time(time, jobs)
       end
 
-      @jobs.each do |mailto, time_and_jobs|
+      @jobs.sort.each do |mailto, time_and_jobs|
         output_jobs = []
 
         time_and_jobs.each do |time, jobs|

--- a/test/functional/output_jobs_with_mailto_test.rb
+++ b/test/functional/output_jobs_with_mailto_test.rb
@@ -5,7 +5,7 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     output = Whenever.cron \
     <<-file
       every 2.hours do
-        command "blahblah", mailto: 'someone@example.com'
+        command "blahblah", :mailto => 'someone@example.com'
       end
     file
 
@@ -18,7 +18,7 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
   test "defined job with every method's block and a mailto argument" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, mailto: 'someone@example.com' do
+      every 2.hours, :mailto => 'someone@example.com' do
         command "blahblah"
       end
     file
@@ -32,8 +32,8 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
   test "defined job which overrided mailto argument in the block" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, mailto: 'of_the_block@example.com' do
-        command "blahblah", mailto: 'overrided_in_the_block@example.com'
+      every 2.hours, :mailto => 'of_the_block@example.com' do
+        command "blahblah", :mailto => 'overrided_in_the_block@example.com'
       end
     file
 
@@ -50,18 +50,18 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, mailto: 'john@example.com' do
+      every 2.hours, :mailto => 'john@example.com' do
         command "blahblah_of_john"
         command "blahblah2_of_john"
       end
 
-      every 2.hours, mailto: 'sarah@example.com' do
+      every 2.hours, :mailto => 'sarah@example.com' do
         command "blahblah_of_sarah"
       end
 
       every 2.hours do
-        command "blahblah_of_martin", mailto: 'martin@example.com'
-        command "blahblah2_of_sarah", mailto: 'sarah@example.com'
+        command "blahblah_of_martin", :mailto => 'martin@example.com'
+        command "blahblah2_of_sarah", :mailto => 'sarah@example.com'
       end
 
       every 2.hours do
@@ -78,18 +78,19 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_john'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_john'", output_without_empty_line.shift
 
+    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
+
     assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_sarah'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_sarah'", output_without_empty_line.shift
 
-    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
-    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
   end
 
   test "defined some jobs with no mailto argument jobs and mailto argument jobs(no mailto jobs should be first line of cron output" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, mailto: 'john@example.com' do
+      every 2.hours, :mailto => 'john@example.com' do
         command "blahblah_of_john"
         command "blahblah2_of_john"
       end
@@ -117,12 +118,12 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, mailto: 'sarah@example.com' do
+      every 2.hours, :mailto => 'sarah@example.com' do
         command "blahblah_by_sarah"
       end
 
       every 2.hours do
-        command "blahblah_by_john", mailto: 'john@example.com'
+        command "blahblah_by_john", :mailto => 'john@example.com'
       end
 
       every 2.hours do
@@ -136,17 +137,17 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2'", output_without_empty_line.shift
 
-    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
-    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_sarah'", output_without_empty_line.shift
-
     assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_john'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_sarah'", output_without_empty_line.shift
   end
 end
 
 class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
   test "one role requested and specified on the job with mailto argument" do
-    output = Whenever.cron roles: [:role1], :string => \
+    output = Whenever.cron :roles => [:role1], :string => \
     <<-file
       env 'MAILTO', 'default@example.com'
 
@@ -154,7 +155,7 @@ class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, mailto: 'sarah@example.com', :roles => [:role2] do
+      every 2.hours, :mailto => 'sarah@example.com', :roles => [:role2] do
         command "blahblah_by_sarah"
       end
     file

--- a/test/functional/output_jobs_with_mailto_test.rb
+++ b/test/functional/output_jobs_with_mailto_test.rb
@@ -1,0 +1,168 @@
+require 'test_helper'
+
+class OutputJobsWithMailtoTest < Whenever::TestCase
+  test "defined job with a mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours do
+        command "blahblah", mailto: 'someone@example.com'
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=someone@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+  end
+
+  test "defined job with every method's block and a mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours, mailto: 'someone@example.com' do
+        command "blahblah"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=someone@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+  end
+
+  test "defined job which overrided mailto argument in the block" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours, mailto: 'of_the_block@example.com' do
+        command "blahblah", mailto: 'overrided_in_the_block@example.com'
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=overrided_in_the_block@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+  end
+
+  test "defined some jobs with various mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours do
+        command "blahblah"
+      end
+
+      every 2.hours, mailto: 'john@example.com' do
+        command "blahblah_of_john"
+        command "blahblah2_of_john"
+      end
+
+      every 2.hours, mailto: 'sarah@example.com' do
+        command "blahblah_of_sarah"
+      end
+
+      every 2.hours do
+        command "blahblah_of_martin", mailto: 'martin@example.com'
+        command "blahblah2_of_sarah", mailto: 'sarah@example.com'
+      end
+
+      every 2.hours do
+        command "blahblah2"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_john'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_john'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_sarah'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_sarah'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
+  end
+
+  test "defined some jobs with no mailto argument jobs and mailto argument jobs(no mailto jobs should be first line of cron output" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours, mailto: 'john@example.com' do
+        command "blahblah_of_john"
+        command "blahblah2_of_john"
+      end
+
+      every 2.hours do
+        command "blahblah"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_john'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_john'", output_without_empty_line.shift
+  end
+
+  test "defined some jobs with environment mailto define and various mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      env 'MAILTO', 'default@example.com'
+
+      every 2.hours do
+        command "blahblah"
+      end
+
+      every 2.hours, mailto: 'sarah@example.com' do
+        command "blahblah_by_sarah"
+      end
+
+      every 2.hours do
+        command "blahblah_by_john", mailto: 'john@example.com'
+      end
+
+      every 2.hours do
+        command "blahblah2"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=default@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_sarah'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_john'", output_without_empty_line.shift
+  end
+end
+
+class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
+  test "one role requested and specified on the job with mailto argument" do
+    output = Whenever.cron roles: [:role1], :string => \
+    <<-file
+      env 'MAILTO', 'default@example.com'
+
+      every 2.hours, :roles => [:role1] do
+        command "blahblah"
+      end
+
+      every 2.hours, mailto: 'sarah@example.com', :roles => [:role2] do
+        command "blahblah_by_sarah"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=default@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+    assert_equal nil, output_without_empty_line.shift
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,10 @@ module Whenever::TestHelpers
       cron = parse_time(Whenever.seconds(2, :hours), 'some task', time)
       assert_equal expected, cron.split(' ')[0]
     end
+
+    def lines_without_empty_line(lines)
+      lines.map { |line| line.chomp }.reject { |line| line.empty? }
+    end
 end
 
 Whenever::TestCase.send(:include, Whenever::TestHelpers)


### PR DESCRIPTION
I've added the feature to customize `MAILTO` per job.
#279 and #503 are related to this feature.

It adds the mailto parameter to:
- the method `every` for setting `MAILTO` for multiple jobs

```
every 1.minutes, mailto: 'someone@example.com' do
  command 'blahblah'
end
```
- the method job for setting `MAILTO` for a single job

```
every 1.minutes do
  command 'blahblah', mailto: 'someone@example.com'
end
```
