### PR TITLE
sometimes you have to use different whenever_command's on different servers

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -1,9 +1,9 @@
 namespace :whenever do
   def setup_whenever_task(*args, &block)
-    args = Array(fetch(:whenever_command)) + args
-
     on roles fetch(:whenever_roles) do |host|
-      args_for_host = block_given? ? args + Array(yield(host)) : args
+      whenever_command = fetch(:whenever_command)
+      whenever_command = whenever_command.call(host) if whenever_command.respond_to?(:call)
+      args_for_host = block_given? ? (whenever_command + args + Array(yield(host))) : (whenever_command + args)
       within fetch(:whenever_path) do
         with fetch(:whenever_command_environment_variables) do
           execute(*args_for_host)


### PR DESCRIPTION
Some of my servers need to update the root crontab, but others don't.  I could just prefix the whenever command with `sudo` and use the `--user` option (which would also require a PR), but that would mean I'm updating everyone's crontab with unnecessarily elevated privileges.  I'd much rather be able to use `sudo` only when necessary.

That means `:whenever_command` needs to support procs so that I can do this:

```
set :whenever_command, ->{ 
  ->(host){ 
  command = [:bundle, :exec, :whenever]
  if "ec2-user" == host.user
    command = [:sudo] + SSHKit.config.command_map.prefix[:bundle] + command 
  end
  command
  } 
}
```
