### PR TITLE
random times for :hour and :day

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,15 @@ $ whenever
 
 This will simply show you your `schedule.rb` file converted to cron syntax. It does not read or write your crontab file. Run `whenever --help` for a complete list of options.
 
+### ExceptionNotification
+ 
+If you are using the exception_notification gem (<https://github.com/smartinez87/exception_notification>), enable it for your "runner" cronjobs with:
+
+In your "schedule.rb" file:
+`set :runner_exception_notification, true`
+
+This will catch all commands defined as "runner", handle it with ExceptionNotification (and raise the exception nevertheless).
+
 ### Credit
 
 Whenever was created for use at Inkling (<http://inklingmarkets.com>). Their take on it: <http://blog.inklingmarkets.com/2009/02/whenever-easy-way-to-do-cron-jobs-from.html>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ every 1.day, :at => '4:30 am' do
   runner "MyModel.task_to_run_at_four_thirty_in_the_morning"
 end
 
+# Note: If you use the Symbol-Shortcut (:hour or :day at the moment) and leave the at-argument blank, the exact time of execution will be randomized
 every :hour do # Many shortcuts available: :hour, :day, :month, :year, :reboot
   runner "SomeModel.ladeeda"
 end

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -12,7 +12,25 @@ module Whenever
         @at_given = at
         @time = time
         @task = task
+        
+        at = randomize_at(at,time)
+        
         @at   = at.is_a?(String) ? (Chronic.parse(at) || 0) : (at || 0)
+
+      end
+
+      def randomize_at(at, time)
+        return at if at.present?
+        unless time.is_a?(Symbol) && time.in?([:hour,:day])
+          #puts 'Sorry, the randomizing-feature works only for symbols :hour and :day'
+          return at
+        end
+
+        case time
+          when :hour  then return Random.rand(0...59)
+          when :day   then return [23,0,1,2,3,4,5,6,7].sample.to_s + ':' + Random.rand(0...59).to_s
+        end
+        return at
       end
 
       def self.enumerate(item, detect_cron = true)

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -20,8 +20,8 @@ module Whenever
       end
 
       def randomize_at(at, time)
-        return at if at.present?
-        unless time.is_a?(Symbol) && time.in?([:hour,:day])
+        return at unless at.nil?
+        unless time.is_a?(Symbol) && [:hour,:day].include?(time)
           #puts 'Sorry, the randomizing-feature works only for symbols :hour and :day'
           return at
         end

--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -33,6 +33,10 @@ module Whenever
         before_and_after = [$`[-1..-1], $'[0..0]]
         option = options[key.sub(':', '').to_sym] || key
 
+        if @options[:runner_exception_notification] && options[:job_type_name]==:runner  && key == ':task' 
+          option = 'begin; ' + option + '; rescue => e;   ExceptionNotifier.notify_exception(e); raise e; end'
+        end
+
         if before_and_after.all? { |c| c == "'" }
           escape_single_quotes(option)
         elsif before_and_after.all? { |c| c == '"' }

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -54,6 +54,7 @@ module Whenever
           options[:output] = (options[:cron_log] || @cron_log) if defined?(@cron_log) || options.has_key?(:cron_log)
           # :output is the newer, more flexible option.
           options[:output] = @output if defined?(@output) && !options.has_key?(:output)
+          options[:job_type_name]   = name
 
           @jobs[@current_time_scope] ||= []
           @jobs[@current_time_scope] << Whenever::Job.new(@options.merge(@set_variables).merge(options))

--- a/test/functional/output_jobs_for_roles_test.rb
+++ b/test/functional/output_jobs_for_roles_test.rb
@@ -60,6 +60,7 @@ class OutputJobsForRolesTest < Whenever::TestCase
     file
 
     assert_match two_hours + " /bin/bash -l -c 'role1_cmd'", output
-    assert_match "0 * * * * /bin/bash -l -c 'role2_cmd'", output
+    #assert_match "0 * * * * /bin/bash -l -c 'role2_cmd'", output
+    assert_match /^[1-5]?[0-9]( \*){4} \/bin\/bash -l -c 'role2_cmd'$/ ,                output
   end
 end

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -192,8 +192,8 @@ class CronParseShortcutsTest < Whenever::TestCase
 
   should "convert time-based shortcuts to times" do
     assert_equal '0 0 1 * *',  parse_time(:month)
-    assert_equal '0 0 * * *',  parse_time(:day)
-    assert_equal '0 * * * *',  parse_time(:hour)
+    assert_match /^[1-5]?[0-9] ([1]?[0-9]|2[0-3])( \*){3}$/ , parse_time(:day)
+    assert_match /^[1-5]?[0-9]( \*){4}$/ ,                    parse_time(:hour)
     assert_equal '0 0 1 12 *', parse_time(:year)
     assert_equal '0 0 1,8,15,22 * *', parse_time(:week)
   end


### PR DESCRIPTION
If you use the Symbol-Shortcut (:hour or :day at the moment) and leave the at-argument blank, the exact time of execution will be randomized.
This can reduce the load, when multiple jobs run hourly, for example.
