### PR TITLE
same crontab on multiple servers

### DIFF
--- a/bin/whenever_server
+++ b/bin/whenever_server
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require 'whenever'
+require 'redis'
+
+options = {}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: whenever [options]"
+
+  opts.on('-f', '--load-file [schedule file]', 'Default: config/schedule.rb') do |file|
+    options[:file] = file if file
+  end
+end.parse!
+
+job_list = Whenever::JobList.new(file: options[:file] || 'config/schedule.rb')
+
+puts(false) unless job_list.redis_options
+
+redis = Redis.new(job_list.redis_options)
+
+# redis key
+lock = :whenever_server
+
+# get the server that has the lock
+whenever_server = redis.get lock
+
+# if there is no server with the lock, give the lock to the current server
+if whenever_server.nil?
+  redis.multi do
+    redis.setnx lock, Socket.gethostname
+    # expire hourly
+    redis.expire lock, 3600
+  end
+end
+
+# return true/false if the current server should be running the task or not
+puts redis.get(lock) == Socket.gethostname

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -21,6 +21,8 @@ module Whenever
         File.read(options[:file])
       end
 
+      @file = options[:file]
+
       instance_eval(Whenever::NumericSeconds.process_string(setup), setup_file)
       instance_eval(Whenever::NumericSeconds.process_string(schedule), options[:file] || '<eval>')
     end
@@ -48,6 +50,9 @@ module Whenever
       singleton_class_shim.class_eval do
         define_method(name) do |task, *args|
           options = { :task => task, :template => template }
+
+          options[:template] = "cd :path && if whenever_server #{ "-f #{@file}" if @file && @file != 'config/schedule.rb'} >> /dev/null; then #{options[:template]} ; fi" if @redis_options
+
           options.merge!(args[0]) if args[0].is_a? Hash
 
           # :cron_log was an old option for output redirection, it remains for backwards compatibility

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -21,7 +21,7 @@ module Whenever
         File.read(options[:file])
       end
 
-      @file = options[:file]
+      @options = options
 
       instance_eval(Whenever::NumericSeconds.process_string(setup), setup_file)
       instance_eval(Whenever::NumericSeconds.process_string(schedule), options[:file] || '<eval>')
@@ -51,7 +51,7 @@ module Whenever
         define_method(name) do |task, *args|
           options = { :task => task, :template => template }
 
-          options[:template] = "cd :path && if whenever_server #{ "-f #{@file}" if @file && @file != 'config/schedule.rb'} >> /dev/null; then #{options[:template]} ; fi" if @redis_options
+          options[:template] = "cd :path && if whenever_server #{ "-f #{@options[:file]}" if @options[:file] && @options[:file] != 'config/schedule.rb'} >> /dev/null ; then #{options[:template]} ; fi" if @redis_options
 
           options.merge!(args[0]) if args[0].is_a? Hash
 

--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -9,6 +9,9 @@ set :path, Whenever.path
 # http://blog.scoutapp.com/articles/2010/09/07/rvm-and-cron-in-production
 set :job_template, "/bin/bash -l -c ':job'"
 
+# Multiple servers support
+set :redis_options, nil
+
 set :runner_command, case
   when Whenever.bin_rails?
     "bin/rails runner"

--- a/test/functional/output_whenever_server_test.rb
+++ b/test/functional/output_whenever_server_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class OutputWheneverServer < Whenever::TestCase
+  test 'command when the redis_options is set' do
+    output = Whenever.cron \
+    <<-file
+      set :redis_options, url: 'redis://localhost:6379/1'
+      every :hour do
+        set :path, "/tmp"
+        command "blahblah"
+      end
+    file
+
+    assert_match "0 * * * * /bin/bash -l -c 'cd /tmp && if whenever_server >> /dev/null ; then blahblah ; fi'", output
+  end
+end

--- a/whenever.gemspec
+++ b/whenever.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "chronic", ">= 0.6.3"
-
+  s.add_dependency "redis"
   s.add_development_dependency "mocha", ">= 0.9.5"
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"


### PR DESCRIPTION
I have exported whenever tasks on multiple servers, but most of the crontab tasks have an implicit assumption that they should only be run once in their given time frame. Having multiple servers with the same crontab tasks obviously would break this assumption, leading to all kinds of weird bugs. Instead, what if we let the servers use a middleware (in this implementation, redis is used) to communicate and decide which server will run the task. 

in `*.schedule.rb`

    set :redis_options, url: 'redis://localhost:6379/1'

the default value for `:redis_options` is `nil`

and if it is set to something other than `nil`, instead of 

    0 4 * * * /bin/bash -l -c 'cd /path && bundle exec rake sometask --silent >> log/cron.log 2>> log/cron-error.log' 

it would export 

    0 4 * * * /bin/bash -l -c 'cd /path && if whenever_server >> /dev/null ; then cd /path && bundle exec rake sometask --silent >> log/cron.log 2>> log/cron-error.log ; fi'

before executing the job, we would execute the `whenever_server` script that would basically use atomic operations to decide if the job should run on this server on not (guaranteeing that the job is executed only once)


