### PR TITLE
test ruby 2.3.0 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ rvm:
   - jruby
   - jruby-18mode
   - jruby-19mode
+before_install:
+  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.0
   - ree
   - jruby
   - jruby-18mode

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ It's a little bit dated now, but remains a good introduction.
 
 ----
 
-Compatible with Ruby 1.8.7-2.2.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
+Compatible with Ruby 1.8.7-2.3.0, JRuby, and Rubinius. [![Build Status](https://secure.travis-ci.org/javan/whenever.png)](http://travis-ci.org/javan/whenever)
 
 ----
 


### PR DESCRIPTION
I added Ruby 2.3.0 in .travis.yml files.
[Ruby 2.3.0 Released](https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/)