### PR TITLE
Micro fix typo duplicated word 'in' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ require "whenever/capistrano"
 
 Take a look at the load:defaults (bottom of file) task for options you can set. <https://github.com/javan/whenever/blob/master/lib/whenever/capistrano/v3/tasks/whenever.rake>. For example, to namespace the crontab entries by application and stage do this.
 
-In your  in "config/deploy.rb" file:
+In your "config/deploy.rb" file:
 
 ```ruby
 set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }


### PR DESCRIPTION
![screen shot 2016-01-19 at 1 18 03 pm](https://cloud.githubusercontent.com/assets/1169424/12417239/4a9adc48-beaf-11e5-8e34-49c89b231f4b.png)
