### PR TITLE
Supported dynamic set variables when proc given.

### DIFF
--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -32,6 +32,7 @@ module Whenever
       template.gsub(/:\w+/) do |key|
         before_and_after = [$`[-1..-1], $'[0..0]]
         option = options[key.sub(':', '').to_sym] || key
+        option = instance_eval(&option) if option.respond_to? :call
 
         if before_and_after.all? { |c| c == "'" }
           escape_single_quotes(option)

--- a/test/functional/output_set_proc_test.rb
+++ b/test/functional/output_set_proc_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class OutputSetProcTest < Whenever::TestCase
+
+  test "Variables which is dynamically set by proc" do
+    output = Whenever.cron \
+    <<-file
+      set :lock_file_name , proc { @options[:task] }
+      set :job_template, "/bin/bash -l -c 'cd :path && setlock -n /var/run/:lock_file_name  :job'"
+      every 2.hours do
+        set :path, "/tmp"
+        command "blahblah"
+      end
+    file
+
+    assert_match /setlock -n \/var\/run\/blahblah/, output
+  end
+
+  test "Variables which is dynamically set by lambda" do
+    output = Whenever.cron \
+    <<-file
+      set :lock_file_name , lambda { |x| @options[:task] }
+      set :job_template, "/bin/bash -l -c 'cd :path && setlock -n /var/run/:lock_file_name  :job'"
+      every 2.hours do
+        set :path, "/tmp"
+        command "blahblah"
+      end
+    file
+
+    assert_match /setlock -n \/var\/run\/blahblah/, output
+  end
+
+  test "Variables which is dynamically set by proc can be overwritten by command set" do
+    output = Whenever.cron \
+    <<-file
+      set :lock_file_name , proc { @options[:task] }
+      set :job_template, "/bin/bash -l -c 'cd :path && setlock -n /var/run/:lock_file_name  :job'"
+      every 2.hours do
+        set :path, "/tmp"
+        command "blahblah", :lock_file_name  => "custom_lock"
+      end
+    file
+
+    assert_match /setlock -n \/var\/run\/custom_lock/, output
+  end
+
+end

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -60,6 +60,15 @@ class JobTest < Whenever::TestCase
 
     assert_equal "before newline -> <- newline space -> <- space after", job.output
   end
+
+  should "eval when proc/lambda is passed" do
+    job = new_job(
+      :template => 'before :dynamic_foo after',
+      :foo => "percent -> % <- percent",
+      :dynamic_foo => proc { @options[:foo] }
+    )
+    assert_equal %q(before percent -> \% <- percent after), job.output
+  end
 end
 
 
@@ -83,6 +92,15 @@ class JobWithQuotesTest < Whenever::TestCase
   end
 
   should "output escaped double quotes when it's wrapped in them" do
+    job = new_job(
+      :template => 'before ":dynamic_foo" after',
+      :foo => 'quote -> " <- quote',
+      :dynamic_foo => proc { @options[:foo] }
+    )
+    assert_equal %q(before "quote -> \" <- quote" after), job.output
+  end
+
+  should "eval when proc/lambda is passed" do
     job = new_job(
       :template => 'before ":foo" after',
       :foo => 'quote -> " <- quote'
@@ -109,6 +127,16 @@ class JobWithJobTemplateTest < Whenever::TestCase
 
   should "escape double quotes" do
     job = new_job(:template => 'before ":task" after', :task => 'quote -> " <- quote', :job_template => 'left ":job" right')
+    assert_equal %q(left "before \"quote -> \\\" <- quote\" after" right), job.output
+  end
+
+  should "eval when proc/lambda is passed" do
+    job = new_job(
+      :template => 'before ":dynamic_task" after', 
+      :task => 'quote -> " <- quote', 
+      :job_template => 'left ":job" right',
+      :dynamic_task => proc { @options[:task] }
+    )
     assert_equal %q(left "before \"quote -> \\\" <- quote\" after" right), job.output
   end
 end


### PR DESCRIPTION
Let me suggest evaluating procs function when proc is given to a set value.

■Use case example
```
set :lock_file_name , proc { @options[:task] } # => the task name is set
job_type :runner, "setlock -n /tmp/:lock_file_name bin/rails runner -e :environment ':task' :output"
every :day, at: '11am' do
  runner "TestBatch.run" # => lock_file_name is the same as the task name
end
every :day, at: '11am' do
  runner "TestBatch.run( frequency: :daily )", lock_file_name: "custom_lock_daily" #=> lock_file_name can be over written as the custom name
end
```

■Why needed?
`job_type :runner, "setlock -n /tmp/:task bin/rails runner -e :environment ':task' :output"`
is basically good, but not worked in case the task name contains white margin ex: `TestBatch.run( frequency: :daily )`.
I considered the proc evaluating mechanism is required in order to achieve such issue.
What do you think of this request?
