### PR TITLE
Introduce option to set whenever path

### DIFF
--- a/lib/whenever/capistrano/v2/recipes.rb
+++ b/lib/whenever/capistrano/v2/recipes.rb
@@ -11,6 +11,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   _cset(:whenever_variables)    { "environment=#{fetch :whenever_environment}" }
   _cset(:whenever_update_flags) { "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
   _cset(:whenever_clear_flags)  { "--clear-crontab #{fetch :whenever_identifier}" }
+  _cset(:whenever_path)         { fetch :latest_release }
 
   namespace :whenever do
     desc "Update application's crontab entries using Whenever"
@@ -18,7 +19,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       args = {
         :command => fetch(:whenever_command),
         :flags   => fetch(:whenever_update_flags),
-        :path    => fetch(:latest_release)
+        :path    => fetch(:whenever_path)
       }
 
       if whenever_servers.any?
@@ -38,7 +39,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         args = {
           :command => fetch(:whenever_command),
           :flags   => fetch(:whenever_clear_flags),
-          :path    => fetch(:latest_release)
+          :path    => fetch(:whenever_path)
         }
 
         whenever_run_commands(args)

--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -4,7 +4,7 @@ namespace :whenever do
 
     on roles fetch(:whenever_roles) do |host|
       args_for_host = block_given? ? args + Array(yield(host)) : args
-      within release_path do
+      within fetch(:whenever_path) do
         with fetch(:whenever_command_environment_variables) do
           execute *args_for_host
         end
@@ -39,5 +39,6 @@ namespace :load do
     set :whenever_variables,    ->{ "environment=#{fetch :whenever_environment}" }
     set :whenever_update_flags, ->{ "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
     set :whenever_clear_flags,  ->{ "--clear-crontab #{fetch :whenever_identifier}" }
+    set :whenever_path,         ->{ fetch :release_path }
   end
 end


### PR DESCRIPTION
This PR allows setting of the `whenever_path`if the application path is not set as the root path during Capistrano deployment.

`whenever_path` has fallback of release_path/latest_release depending on Capistrano version.

_Note: have not changed the version, please advise which alteration would be preferential_
