### PR TITLE
fix warnings in tests due to the way arguments are passed to assert_match

### DIFF
--- a/test/functional/output_default_defined_jobs_test.rb
+++ b/test/functional/output_default_defined_jobs_test.rb
@@ -13,7 +13,7 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah$/, output)
   end
 
   test "A plain command with no job template set" do
@@ -24,7 +24,7 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ \/bin\/bash -l -c 'blahblah'$/, output
+    assert_match(/^.+ .+ .+ .+ \/bin\/bash -l -c 'blahblah'$/, output)
   end
 
   test "A plain command with a job_template using a normal parameter" do
@@ -37,7 +37,7 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ \/bin\/bash -l -c 'cd \/tmp \&\& blahblah'$/, output
+    assert_match(/^.+ .+ .+ .+ \/bin\/bash -l -c 'cd \/tmp \&\& blahblah'$/, output)
   end
 
   test "A plain command that overrides the job_template set" do
@@ -50,8 +50,8 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
     file
 
 
-    assert_match /^.+ .+ .+ .+ \/bin\/sh -l -c 'blahblah'$/, output
-    assert_no_match /bash/, output
+    assert_match(/^.+ .+ .+ .+ \/bin\/sh -l -c 'blahblah'$/, output)
+    assert_no_match(/bash/, output)
   end
 
   test "A plain command that overrides the job_template set using a parameter" do
@@ -65,8 +65,8 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
     file
 
 
-    assert_match /^.+ .+ .+ .+ \/bin\/sh -l -c 'cd \/tmp && blahblah'$/, output
-    assert_no_match /bash/, output
+    assert_match(/^.+ .+ .+ .+ \/bin\/sh -l -c 'cd \/tmp && blahblah'$/, output)
+    assert_no_match(/bash/, output)
   end
 
   test "A plain command that is conditional on default environent and path" do
@@ -81,7 +81,7 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
       end
     file
 
-    assert_match /blahblah/, output
+    assert_match(/blahblah/, output)
   end
 
   # runner

--- a/test/functional/output_defined_job_test.rb
+++ b/test/functional/output_defined_job_test.rb
@@ -11,7 +11,7 @@ class OutputDefinedJobTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ before during after$/, output
+    assert_match(/^.+ .+ .+ .+ before during after$/, output)
   end
 
   test "defined job with a :task and some options" do
@@ -24,7 +24,7 @@ class OutputDefinedJobTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ before during after happy birthday$/, output
+    assert_match(/^.+ .+ .+ .+ before during after happy birthday$/, output)
   end
 
   test "defined job with a :task and an option where the option is set globally" do
@@ -38,7 +38,7 @@ class OutputDefinedJobTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ before during after happy$/, output
+    assert_match(/^.+ .+ .+ .+ before during after happy$/, output)
   end
 
   test "defined job with a :task and an option where the option is set globally and locally" do
@@ -52,7 +52,7 @@ class OutputDefinedJobTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ before during after local$/, output
+    assert_match(/^.+ .+ .+ .+ before during after local$/, output)
   end
 
   test "defined job with a :task and an option that is not set" do
@@ -65,7 +65,7 @@ class OutputDefinedJobTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ before during after :option1$/, output
+    assert_match(/^.+ .+ .+ .+ before during after :option1$/, output)
   end
 
   test "defined job that uses a :path where none is explicitly set" do

--- a/test/functional/output_redirection_test.rb
+++ b/test/functional/output_redirection_test.rb
@@ -11,7 +11,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> \/dev\/null 2>&1$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> \/dev\/null 2>&1$/, output)
   end
 
 
@@ -25,7 +25,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> logfile.log 2>&1$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> logfile.log 2>&1$/, output)
   end
 
   test "command when the error and standard output is set by the command" do
@@ -37,7 +37,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> dev_null 2>> dev_err$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> dev_null 2>> dev_err$/, output)
   end
 
   test "command when the output is set and the comand overrides it" do
@@ -50,8 +50,8 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_no_match /.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output
-    assert_match /^.+ .+ .+ .+ blahblah >> otherlog.log 2>&1$/, output
+    assert_no_match(/.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output)
+    assert_match(/^.+ .+ .+ .+ blahblah >> otherlog.log 2>&1$/, output)
   end
 
   test "command when the output is set and the comand overrides with standard and error" do
@@ -64,8 +64,8 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_no_match /.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output
-    assert_match /^.+ .+ .+ .+ blahblah >> dev_null 2>> dev_err$/, output
+    assert_no_match(/.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output)
+    assert_match(/^.+ .+ .+ .+ blahblah >> dev_null 2>> dev_err$/, output)
   end
 
   test "command when the output is set and the comand rejects it" do
@@ -78,8 +78,8 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_no_match /.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output
-    assert_match /^.+ .+ .+ .+ blahblah$/, output
+    assert_no_match(/.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output)
+    assert_match(/^.+ .+ .+ .+ blahblah$/, output)
   end
 
   test "command when the output is set and is overridden by the :set option" do
@@ -92,8 +92,8 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_no_match /.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output
-    assert_match /^.+ .+ .+ .+ blahblah >> otherlog.log 2>&1/, output
+    assert_no_match(/.+ .+ .+ .+ blahblah >> logfile.log 2>&1/, output)
+    assert_match(/^.+ .+ .+ .+ blahblah >> otherlog.log 2>&1/, output)
   end
 
   test "command when the error and standard output is set" do
@@ -106,7 +106,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> dev_null 2>> dev_err$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> dev_null 2>> dev_err$/, output)
   end
 
   test "command when error output is set" do
@@ -119,7 +119,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah 2>> dev_null$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah 2>> dev_null$/, output)
   end
 
   test "command when the standard output is set" do
@@ -132,7 +132,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> dev_out$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> dev_out$/, output)
   end
 
   test "command when error output is set by the command" do
@@ -144,7 +144,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah 2>> dev_err$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah 2>> dev_err$/, output)
   end
 
   test "command when standard output is set by the command" do
@@ -156,7 +156,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> dev_out$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> dev_out$/, output)
   end
 
   test "command when standard output is set to nil" do
@@ -168,7 +168,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah > \/dev\/null$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah > \/dev\/null$/, output)
   end
 
   test "command when standard error is set to nil" do
@@ -180,7 +180,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah 2> \/dev\/null$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah 2> \/dev\/null$/, output)
   end
 
   test "command when standard output and standard error is set to nil" do
@@ -192,7 +192,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah > \/dev\/null 2>&1$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah > \/dev\/null 2>&1$/, output)
   end
 
   test "command when standard output is set and standard error is set to nil" do
@@ -204,7 +204,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> my.log 2> \/dev\/null$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> my.log 2> \/dev\/null$/, output)
   end
 
   test "command when standard output is nil and standard error is set" do
@@ -216,7 +216,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> \/dev\/null 2>> my_error.log$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> \/dev\/null 2>> my_error.log$/, output)
   end
 
   test "command when the deprecated :cron_log is set" do
@@ -229,7 +229,7 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah >> cron.log 2>&1$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah >> cron.log 2>&1$/, output)
   end
 
 
@@ -243,6 +243,6 @@ class OutputRedirectionTest < Whenever::TestCase
       end
     file
 
-    assert_match /^.+ .+ .+ .+ blahblah 2>&1 | logger -t whenever_cron$/, output
+    assert_match(/^.+ .+ .+ .+ blahblah 2>&1 | logger -t whenever_cron$/, output)
   end
 end


### PR DESCRIPTION
Hi,
I see a bunch of warning when I run tests. This change will remove those warnings. 


`test/functional/output_default_defined_jobs_test.rb:16: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_default_defined_jobs_test.rb:27: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_default_defined_jobs_test.rb:40: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_default_defined_jobs_test.rb:53: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_default_defined_jobs_test.rb:54: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_default_defined_jobs_test.rb:68: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_default_defined_jobs_test.rb:69: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_default_defined_jobs_test.rb:84: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_defined_job_test.rb:14: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_defined_job_test.rb:27: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_defined_job_test.rb:41: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_defined_job_test.rb:55: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_defined_job_test.rb:68: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:14: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:28: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:40: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:53: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:54: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:67: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:68: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:81: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:82: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:95: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:96: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:109: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:122: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:135: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:147: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:159: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:171: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:183: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:195: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:207: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:219: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:232: warning: ambiguous first argument; put parentheses or a space even after / operator
test/functional/output_redirection_test.rb:246: warning: ambiguous first argument; put parentheses or a space even after / operator
`
