### PR TITLE
Fix interpreted as argument prefix

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -7,7 +7,7 @@ namespace :whenever do
       within release_path do
         with rails_env: fetch(:whenever_environment) do
           with fetch(:whenever_command_environment_variables) do
-            execute *args_for_host
+            execute(*args_for_host)
           end
         end
       end


### PR DESCRIPTION
Hello.
I fixed the warning that `*' interpreted as argument prefix.