### PR TITLE
Remove rails_env

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -5,10 +5,8 @@ namespace :whenever do
     on roles fetch(:whenever_roles) do |host|
       args_for_host = block_given? ? args + Array(yield(host)) : args
       within release_path do
-        with rails_env: fetch(:whenever_environment) do
-          with fetch(:whenever_command_environment_variables) do
-            execute *args_for_host
-          end
+        with fetch(:whenever_command_environment_variables) do
+          execute(*args_for_host)
         end
       end
     end


### PR DESCRIPTION
When I executed whenever:update_crontab on the sinatra application, the following error has occurred.

```
⇒  bundle exec cap qa whenever:update_crontab --trace
** Invoke qa (first_time)
** Execute qa
** Invoke load:defaults (first_time)
** Execute load:defaults
** Invoke bundler:map_bins (first_time)
** Execute bundler:map_bins
** Invoke whenever:update_crontab (first_time)
** Execute whenever:update_crontab
cap aborted!
NameError: instance variable @_env not defined
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:91:in `remove_instance_variable'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:91:in `ensure in with'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:91:in `with'
/Users/shoyan/Development/app/lib/capistrano/tasks/whenever.rake:8:in `block (2 levels) in setup_whenever_task'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:80:in `within'
/Users/shoyan/Development/app/lib/capistrano/tasks/whenever.rake:7:in `block in setup_whenever_task'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:29:in `instance_exec'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:29:in `run'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
TypeError: no implicit conversion of nil into Hash
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:87:in `merge'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:87:in `with'
/Users/shoyan/Development/app/lib/capistrano/tasks/whenever.rake:9:in `block (3 levels) in setup_whenever_task'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:88:in `with'
/Users/shoyan/Development/app/lib/capistrano/tasks/whenever.rake:8:in `block (2 levels) in setup_whenever_task'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:80:in `within'
/Users/shoyan/Development/app/lib/capistrano/tasks/whenever.rake:7:in `block in setup_whenever_task'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:29:in `instance_exec'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/backends/abstract.rb:29:in `run'
/Users/shoyan/Development/app/vendor/bundle/ruby/2.3.0/gems/sshkit-1.9.0/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
Tasks: TOP => whenever:update_crontab
```

I think to use the whenever_command_environment_variables if want to set the rails_env.

```ruby
# config/deploy.rb

set :whenever_command_environment_variables, ->{ { rails_env: fetch(:rails_env) } }
```

