### PR TITLE
Allow specifying the crontab user for capistrano

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }
 
 The Capistrano integration by default expects the `:application` variable to be set in order to scope jobs in the crontab.
 
+If your deploy user is different than your application user, you can specify to set the crontab user with:
+
+```ruby
+set :whenever_user, "appuser"
+```
+
+
 ### Capistrano roles
 
 The first thing to know about the new roles support is that it is entirely

--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -6,9 +6,20 @@ namespace :whenever do
       args_for_host = block_given? ? args + Array(yield(host)) : args
       within release_path do
         with fetch(:whenever_command_environment_variables) do
-          execute(*args_for_host)
+          as_whenever_user do
+            execute(*args_for_host)
+          end
         end
       end
+    end
+  end
+
+  def as_whenever_user(&block)
+    user = fetch(:whenever_user)
+    if user
+      as(user, &block)
+    else
+      block.call
     end
   end
 
@@ -31,6 +42,7 @@ end
 
 namespace :load do
   task :defaults do
+    set :whenever_user,         -> { nil }
     set :whenever_roles,        ->{ :db }
     set :whenever_command,      ->{ [:bundle, :exec, :whenever] }
     set :whenever_command_environment_variables, ->{ { rails_env: fetch(:whenever_environment) } }


### PR DESCRIPTION
This is to support the scenario where there is a separate user for deploying in capistrano than for running the application.