### PR TITLE
Support whenever load_file option for capistrano

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -12,17 +12,28 @@ namespace :whenever do
     end
   end
 
+  def load_file
+    file = fetch(:whenever_load_file)
+    if file
+      "-f #{file}"
+    else
+      ''
+    end
+  end
+
   desc "Update application's crontab entries using Whenever"
   task :update_crontab do
     setup_whenever_task do |host|
       roles = host.roles_array.join(",")
-      [fetch(:whenever_update_flags),  "--roles=#{roles}"]
+      [fetch(:whenever_update_flags), "--roles=#{roles}", load_file]
     end
   end
 
   desc "Clear application's crontab entries using Whenever"
   task :clear_crontab do
-    setup_whenever_task(fetch(:whenever_clear_flags))
+    setup_whenever_task do |host|
+      [fetch(:whenever_clear_flags), load_file]
+    end
   end
 
   after "deploy:updated",  "whenever:update_crontab"
@@ -37,6 +48,7 @@ namespace :load do
     set :whenever_identifier,   ->{ fetch :application }
     set :whenever_environment,  ->{ fetch :rails_env, fetch(:stage, "production") }
     set :whenever_variables,    ->{ "environment=#{fetch :whenever_environment}" }
+    set :whenever_load_file,    ->{ nil }
     set :whenever_update_flags, ->{ "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
     set :whenever_clear_flags,  ->{ "--clear-crontab #{fetch :whenever_identifier}" }
   end


### PR DESCRIPTION
I want to change whenever schedule file path.
I add `whenever_load_file` option.
### Example

deploy.rb

``` rb
...

set :whenever_load_file, -> {  "#{release_path}/config/any/schedule.rb" }
set :whenever_identifier, -> { "#{fetch(:application)}" }
set :whenever_roles, [:db]

...
```

outputs

> cd /home/ubuntu/myapp/current && ( export PATH="/user/ubuntu/.rbenv/shims:/user/ubuntu/.rbenv/bin:$PATH" RBENV_ROOT="~/.rbenv" RBENV_VERSION="2.3.1" RAILS_ENV="production" ; /usr/bin/env RBENV_ROOT=~/.rbenv RBENV_VERSION=2.3.1 ~/.rbenv/bin/rbenv exec bundle exec whenever --update-crontab myapp --set environment=production --roles=db -f /home/ubuntu/myapp/current/config/any/schedule.rb
