### PR TITLE
Test: CLI test typo

### DIFF
--- a/test/functional/command_line_test.rb
+++ b/test/functional/command_line_test.rb
@@ -175,7 +175,7 @@ class CommandLineUpdateWithNoIdentifierTest < Whenever::TestCase
   setup do
     File.expects(:exist?).with('config/schedule.rb').returns(true)
     Whenever::CommandLine.any_instance.expects(:default_identifier).returns('DEFAULT')
-    @command = Whenever::CommandLine.new(:update => true, :file => @file)
+    @command = Whenever::CommandLine.new(:update => true)
   end
 
   should "use the default identifier" do


### PR DESCRIPTION
This PR removes a warning from the test run.

  - removing this (which was `nil`) tests the same behavior
  - removing this removes a Ruby warning from the output of the tests