### PR TITLE
adding feature: changing MAILTO per job, just remaking of #577

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ If you want to change `MAILTO` per jobs, you can specify as below ways.
 
 ```ruby
 every 3.hours do
-  command "/usr/bin/my_super_command", :mailto => 'my_super_command_output@example.com'
+  command "/usr/bin/my_super_command", mailto: 'my_super_command_output@example.com'
 end
 ```
 
 or
 
 ```ruby
-every 3.hours, :mailto => 'my_super_command_output@example.com'  do
+every 3.hours, mailto: 'my_super_command@example.com'  do
   command "/usr/bin/my_super_command"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ If you want to change `MAILTO` per jobs, you can specify as below ways.
 
 ```ruby
 every 3.hours do
-  command "/usr/bin/my_super_command", mailto: 'my_super_command_output@example.com'
+  command "/usr/bin/my_super_command", :mailto => 'my_super_command_output@example.com'
 end
 ```
 
 or
 
 ```ruby
-every 3.hours, mailto: 'my_super_command@example.com'  do
+every 3.hours, :mailto => 'my_super_command_output@example.com'  do
   command "/usr/bin/my_super_command"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,36 @@ Or set the job_template to nil to have your jobs execute normally.
 set :job_template, nil
 ```
 
+### Customize `MAILTO` environment variable
+
+You can specify `MAILTO` environment variable, which is recipient address of the email that contains output from the jobs.
+
+For example:
+
+```ruby
+env 'MAILTO', 'output_of_cron@example.com'
+
+every 3.hours do
+  command "/usr/bin/my_great_command"
+end
+```
+
+If you want to change `MAILTO` per jobs, you can specify as below ways.
+
+```ruby
+every 3.hours do
+  command "/usr/bin/my_super_command", mailto: 'my_super_command_output@example.com'
+end
+```
+
+or
+
+```ruby
+every 3.hours, mailto: 'my_super_command@example.com'  do
+  command "/usr/bin/my_super_command"
+end
+```
+
 ### Capistrano integration
 
 Use the built-in Capistrano recipe for easy crontab updates with deploys. For Capistrano V3, see the next section.

--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -2,12 +2,13 @@ require 'shellwords'
 
 module Whenever
   class Job
-    attr_reader :at, :roles
+    attr_reader :at, :roles, :mailto
 
     def initialize(options = {})
       @options = options
       @at                               = options.delete(:at)
       @template                         = options.delete(:template)
+      @mailto                           = options.fetch(:mailto, :default_mailto)
       @job_template                     = options.delete(:job_template) || ":job"
       @roles                            = Array(options.delete(:roles))
       @options[:output]                 = options.has_key?(:output) ? Whenever::Output::Redirection.new(options[:output]).to_s : ''

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -166,7 +166,7 @@ module Whenever
         output << cron_jobs_of_time(time, jobs)
       end
 
-      @jobs.each do |mailto, time_and_jobs|
+      @jobs.sort.each do |mailto, time_and_jobs|
         output_jobs = []
 
         time_and_jobs.each do |time, jobs|

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -166,7 +166,7 @@ module Whenever
         output << cron_jobs_of_time(time, jobs)
       end
 
-      @jobs.sort.each do |mailto, time_and_jobs|
+      @jobs.each do |mailto, time_and_jobs|
         output_jobs = []
 
         time_and_jobs.each do |time, jobs|

--- a/test/functional/output_jobs_with_mailto_test.rb
+++ b/test/functional/output_jobs_with_mailto_test.rb
@@ -5,7 +5,7 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     output = Whenever.cron \
     <<-file
       every 2.hours do
-        command "blahblah", mailto: 'someone@example.com'
+        command "blahblah", :mailto => 'someone@example.com'
       end
     file
 
@@ -18,7 +18,7 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
   test "defined job with every method's block and a mailto argument" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, mailto: 'someone@example.com' do
+      every 2.hours, :mailto => 'someone@example.com' do
         command "blahblah"
       end
     file
@@ -32,8 +32,8 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
   test "defined job which overrided mailto argument in the block" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, mailto: 'of_the_block@example.com' do
-        command "blahblah", mailto: 'overrided_in_the_block@example.com'
+      every 2.hours, :mailto => 'of_the_block@example.com' do
+        command "blahblah", :mailto => 'overrided_in_the_block@example.com'
       end
     file
 
@@ -50,18 +50,18 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, mailto: 'john@example.com' do
+      every 2.hours, :mailto => 'john@example.com' do
         command "blahblah_of_john"
         command "blahblah2_of_john"
       end
 
-      every 2.hours, mailto: 'sarah@example.com' do
+      every 2.hours, :mailto => 'sarah@example.com' do
         command "blahblah_of_sarah"
       end
 
       every 2.hours do
-        command "blahblah_of_martin", mailto: 'martin@example.com'
-        command "blahblah2_of_sarah", mailto: 'sarah@example.com'
+        command "blahblah_of_martin", :mailto => 'martin@example.com'
+        command "blahblah2_of_sarah", :mailto => 'sarah@example.com'
       end
 
       every 2.hours do
@@ -78,18 +78,19 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_john'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_john'", output_without_empty_line.shift
 
+    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
+
     assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_sarah'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_sarah'", output_without_empty_line.shift
 
-    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
-    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
   end
 
   test "defined some jobs with no mailto argument jobs and mailto argument jobs(no mailto jobs should be first line of cron output" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, mailto: 'john@example.com' do
+      every 2.hours, :mailto => 'john@example.com' do
         command "blahblah_of_john"
         command "blahblah2_of_john"
       end
@@ -117,12 +118,12 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, mailto: 'sarah@example.com' do
+      every 2.hours, :mailto => 'sarah@example.com' do
         command "blahblah_by_sarah"
       end
 
       every 2.hours do
-        command "blahblah_by_john", mailto: 'john@example.com'
+        command "blahblah_by_john", :mailto => 'john@example.com'
       end
 
       every 2.hours do
@@ -136,17 +137,17 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2'", output_without_empty_line.shift
 
-    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
-    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_sarah'", output_without_empty_line.shift
-
     assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_john'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_sarah'", output_without_empty_line.shift
   end
 end
 
 class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
   test "one role requested and specified on the job with mailto argument" do
-    output = Whenever.cron roles: [:role1], :string => \
+    output = Whenever.cron :roles => [:role1], :string => \
     <<-file
       env 'MAILTO', 'default@example.com'
 
@@ -154,7 +155,7 @@ class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, mailto: 'sarah@example.com', :roles => [:role2] do
+      every 2.hours, :mailto => 'sarah@example.com', :roles => [:role2] do
         command "blahblah_by_sarah"
       end
     file

--- a/test/functional/output_jobs_with_mailto_test.rb
+++ b/test/functional/output_jobs_with_mailto_test.rb
@@ -5,7 +5,7 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     output = Whenever.cron \
     <<-file
       every 2.hours do
-        command "blahblah", :mailto => 'someone@example.com'
+        command "blahblah", mailto: 'someone@example.com'
       end
     file
 
@@ -18,7 +18,7 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
   test "defined job with every method's block and a mailto argument" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, :mailto => 'someone@example.com' do
+      every 2.hours, mailto: 'someone@example.com' do
         command "blahblah"
       end
     file
@@ -32,8 +32,8 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
   test "defined job which overrided mailto argument in the block" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, :mailto => 'of_the_block@example.com' do
-        command "blahblah", :mailto => 'overrided_in_the_block@example.com'
+      every 2.hours, mailto: 'of_the_block@example.com' do
+        command "blahblah", mailto: 'overrided_in_the_block@example.com'
       end
     file
 
@@ -50,18 +50,18 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, :mailto => 'john@example.com' do
+      every 2.hours, mailto: 'john@example.com' do
         command "blahblah_of_john"
         command "blahblah2_of_john"
       end
 
-      every 2.hours, :mailto => 'sarah@example.com' do
+      every 2.hours, mailto: 'sarah@example.com' do
         command "blahblah_of_sarah"
       end
 
       every 2.hours do
-        command "blahblah_of_martin", :mailto => 'martin@example.com'
-        command "blahblah2_of_sarah", :mailto => 'sarah@example.com'
+        command "blahblah_of_martin", mailto: 'martin@example.com'
+        command "blahblah2_of_sarah", mailto: 'sarah@example.com'
       end
 
       every 2.hours do
@@ -78,19 +78,18 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_john'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_john'", output_without_empty_line.shift
 
-    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
-    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
-
     assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_sarah'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_sarah'", output_without_empty_line.shift
 
+    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
   end
 
   test "defined some jobs with no mailto argument jobs and mailto argument jobs(no mailto jobs should be first line of cron output" do
     output = Whenever.cron \
     <<-file
-      every 2.hours, :mailto => 'john@example.com' do
+      every 2.hours, mailto: 'john@example.com' do
         command "blahblah_of_john"
         command "blahblah2_of_john"
       end
@@ -118,12 +117,12 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, :mailto => 'sarah@example.com' do
+      every 2.hours, mailto: 'sarah@example.com' do
         command "blahblah_by_sarah"
       end
 
       every 2.hours do
-        command "blahblah_by_john", :mailto => 'john@example.com'
+        command "blahblah_by_john", mailto: 'john@example.com'
       end
 
       every 2.hours do
@@ -137,17 +136,17 @@ class OutputJobsWithMailtoTest < Whenever::TestCase
     assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah2'", output_without_empty_line.shift
 
-    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
-    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_john'", output_without_empty_line.shift
-
     assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_sarah'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_john'", output_without_empty_line.shift
   end
 end
 
 class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
   test "one role requested and specified on the job with mailto argument" do
-    output = Whenever.cron :roles => [:role1], :string => \
+    output = Whenever.cron roles: [:role1], :string => \
     <<-file
       env 'MAILTO', 'default@example.com'
 
@@ -155,7 +154,7 @@ class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
         command "blahblah"
       end
 
-      every 2.hours, :mailto => 'sarah@example.com', :roles => [:role2] do
+      every 2.hours, mailto: 'sarah@example.com', :roles => [:role2] do
         command "blahblah_by_sarah"
       end
     file

--- a/test/functional/output_jobs_with_mailto_test.rb
+++ b/test/functional/output_jobs_with_mailto_test.rb
@@ -1,0 +1,168 @@
+require 'test_helper'
+
+class OutputJobsWithMailtoTest < Whenever::TestCase
+  test "defined job with a mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours do
+        command "blahblah", mailto: 'someone@example.com'
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=someone@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+  end
+
+  test "defined job with every method's block and a mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours, mailto: 'someone@example.com' do
+        command "blahblah"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=someone@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+  end
+
+  test "defined job which overrided mailto argument in the block" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours, mailto: 'of_the_block@example.com' do
+        command "blahblah", mailto: 'overrided_in_the_block@example.com'
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=overrided_in_the_block@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+  end
+
+  test "defined some jobs with various mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours do
+        command "blahblah"
+      end
+
+      every 2.hours, mailto: 'john@example.com' do
+        command "blahblah_of_john"
+        command "blahblah2_of_john"
+      end
+
+      every 2.hours, mailto: 'sarah@example.com' do
+        command "blahblah_of_sarah"
+      end
+
+      every 2.hours do
+        command "blahblah_of_martin", mailto: 'martin@example.com'
+        command "blahblah2_of_sarah", mailto: 'sarah@example.com'
+      end
+
+      every 2.hours do
+        command "blahblah2"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_john'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_john'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_sarah'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_sarah'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=martin@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_martin'", output_without_empty_line.shift
+  end
+
+  test "defined some jobs with no mailto argument jobs and mailto argument jobs(no mailto jobs should be first line of cron output" do
+    output = Whenever.cron \
+    <<-file
+      every 2.hours, mailto: 'john@example.com' do
+        command "blahblah_of_john"
+        command "blahblah2_of_john"
+      end
+
+      every 2.hours do
+        command "blahblah"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_of_john'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2_of_john'", output_without_empty_line.shift
+  end
+
+  test "defined some jobs with environment mailto define and various mailto argument" do
+    output = Whenever.cron \
+    <<-file
+      env 'MAILTO', 'default@example.com'
+
+      every 2.hours do
+        command "blahblah"
+      end
+
+      every 2.hours, mailto: 'sarah@example.com' do
+        command "blahblah_by_sarah"
+      end
+
+      every 2.hours do
+        command "blahblah_by_john", mailto: 'john@example.com'
+      end
+
+      every 2.hours do
+        command "blahblah2"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=default@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah2'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=sarah@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_sarah'", output_without_empty_line.shift
+
+    assert_equal 'MAILTO=john@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah_by_john'", output_without_empty_line.shift
+  end
+end
+
+class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
+  test "one role requested and specified on the job with mailto argument" do
+    output = Whenever.cron roles: [:role1], :string => \
+    <<-file
+      env 'MAILTO', 'default@example.com'
+
+      every 2.hours, :roles => [:role1] do
+        command "blahblah"
+      end
+
+      every 2.hours, mailto: 'sarah@example.com', :roles => [:role2] do
+        command "blahblah_by_sarah"
+      end
+    file
+
+    output_without_empty_line = lines_without_empty_line(output.lines)
+
+    assert_equal 'MAILTO=default@example.com', output_without_empty_line.shift
+    assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
+    assert_equal nil, output_without_empty_line.shift
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,10 @@ module Whenever::TestHelpers
       cron = parse_time(Whenever.seconds(2, :hours), 'some task', time)
       assert_equal expected, cron.split(' ')[0]
     end
+
+    def lines_without_empty_line(lines)
+      lines.map { |line| line.chomp }.reject { |line| line.empty? }
+    end
 end
 
 Whenever::TestCase.send(:include, Whenever::TestHelpers)


### PR DESCRIPTION
remaking pull request of #577, just drop ruby 1.8.7 support 

---

I've added the feature to customize `MAILTO` per job.
#279 and #503 are related to this feature.

It adds the mailto parameter to:
- the method `every` for setting `MAILTO` for multiple jobs

```
every 1.minutes, mailto: 'someone@example.com' do
  command 'blahblah'
end
```
- the method job for setting `MAILTO` for a single job

```
every 1.minutes do
  command 'blahblah', mailto: 'someone@example.com'
end
```
