### PR TITLE
fix test failure

### DIFF
--- a/test/unit/executable_test.rb
+++ b/test/unit/executable_test.rb
@@ -81,15 +81,16 @@ describe 'Executable' do
 
       describe 'config directory does not exist' do
         it 'prints STDOUT and STDERR' do
-          out, err = capture_subprocess_io do
-            system('wheneverize')
-          end
+          begin
+            out, err = capture_subprocess_io do
+              system('wheneverize')
+            end
 
-          assert_match(/\[done\] wheneverized!/, out)
-          assert_match(
-            %r{\[skip\] directory `#{File.dirname(path)}' does not exist},
-            err
-          )
+            assert_match(%r{\[add\] creating `#{File.dirname(path)}'\n}, err)
+            assert_match(/\[done\] wheneverized!/, out)
+          ensure
+            FileUtils.rm_rf(File.dirname(path))
+          end
         end
       end
 

--- a/test/unit/executable_test.rb
+++ b/test/unit/executable_test.rb
@@ -86,7 +86,7 @@ describe 'Executable' do
               system('wheneverize')
             end
 
-            assert_match(%r{\[add\] creating `#{File.dirname(path)}'\n}, err)
+            assert_match(/\[add\] creating `#{File.dirname(path)}'\n/, err)
             assert_match(/\[done\] wheneverized!/, out)
           ensure
             FileUtils.rm_rf(File.dirname(path))


### PR DESCRIPTION
the behavior of `wheneverize` command when config directory is not present was changed by c7675c81d34131f7107b2930c207c9b994895a08, but test was not.