### PR TITLE
[Fix #582] Raise ArgumentErrors for out of bound minute, hour and day values

### DIFF
--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -95,11 +95,13 @@ module Whenever
             hour_frequency = (@time / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min : @at
             timing[1] = comma_separated_timing(hour_frequency, 23)
+            raise ArgumentError, "Minute must be between 0-59, #{timing[0]} given" unless (0..59).include?(timing[0])
           when Whenever.seconds(1, :day)...Whenever.seconds(1, :month)
             day_frequency = (@time / 24 / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min  : 0
             timing[1] = @at.is_a?(Time) ? @at.hour : @at
             timing[2] = comma_separated_timing(day_frequency, 31, 1)
+            raise ArgumentError, "Hour must be between 0-23, #{timing[1]} given" unless (0..23).include?(timing[1])
           when Whenever.seconds(1, :month)..Whenever.seconds(12, :months)
             month_frequency = (@time / 30  / 24 / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min  : 0
@@ -110,6 +112,7 @@ module Whenever
               @at.zero? ? 1 : @at
             end
             timing[3] = comma_separated_timing(month_frequency, 12, 1)
+            raise ArgumentError, "Day must be between 1-31, #{timing[2]} given" unless (1..31).include?(timing[2])
           else
             return parse_as_string
         end

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -67,6 +67,16 @@ class CronParseHoursTest < Whenever::TestCase
     assert_minutes_equals "0",  'midnight'
     assert_minutes_equals "59", '13:59'
   end
+
+  should "raise an exception when given an 'at' with an invalid minute value" do
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :hour), nil, 60)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :hour), nil, -1)
+    end
+  end
 end
 
 class CronParseDaysTest < Whenever::TestCase
@@ -97,6 +107,16 @@ class CronParseDaysTest < Whenever::TestCase
     assert_hours_and_minutes_equals %w(15 0), 15
     assert_hours_and_minutes_equals %w(19 0), 19
     assert_hours_and_minutes_equals %w(23 0), 23
+  end
+
+  should "raise an exception when given an 'at' with an invalid hour value" do
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :day), nil, 24)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :day), nil, -1)
+    end
   end
 end
 
@@ -137,6 +157,16 @@ class CronParseMonthsTest < Whenever::TestCase
     assert_days_and_hours_and_minutes_equals %w(1 0 0),  1
     assert_days_and_hours_and_minutes_equals %w(15 0 0), 15
     assert_days_and_hours_and_minutes_equals %w(29 0 0), 29
+  end
+
+  should "raise an exception when given an 'at' with an invalid day value" do
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :month), nil, 32)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :month), nil, -1)
+    end
   end
 end
 


### PR DESCRIPTION
Right now it's possible to define out of bound minute, hour and day values by using the `at:` argument with raw integers:

```ruby
every 1.hour, at: 70 do
  runner 'Test'
end

# Generates 70 * * * *

every 1.day, at: 50 do
  runner 'Test'
end

# Generates 0 50 * * *

every 1.month, at: 42 do
  runner 'Test'
end

# Generates 0 0 42 * *
```

This PR adds bounds checking for these, raising an ArgumentError if a wrong value was supplied.

This fixes https://github.com/javan/whenever/issues/582.