### PR TITLE
[Fix #668] Add support for custom Chronic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,25 @@ Or set the job_template to nil to have your jobs execute normally.
 set :job_template, nil
 ```
 
+### Parsing dates and times
+
+Whenever uses the [Chronic](https://github.com/mojombo/chronic) gem to parse the specified dates and times.
+
+You can set your custom Chronic configuration if the defaults don't fit you.
+
+For example, to assume a 24 hour clock instead of the default 12 hour clock:
+
+```ruby
+set :chronic_options, :hours24 => true
+
+# By default this would run the job every day at 3pm
+every 1.day, :at => '3:00' do
+  runner "MyModel.nightly_archive_job"
+end
+```
+
+You can see a list of all available options here: <https://github.com/mojombo/chronic/blob/master/lib/chronic/parser.rb>
+
 ### Capistrano integration
 
 Use the built-in Capistrano recipe for easy crontab updates with deploys. For Capistrano V3, see the next section.

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -8,11 +8,13 @@ module Whenever
 
       attr_accessor :time, :task
 
-      def initialize(time = nil, task = nil, at = nil)
+      def initialize(time = nil, task = nil, at = nil, options = {})
+        chronic_options = options[:chronic_options] || {}
+
         @at_given = at
         @time = time
         @task = task
-        @at   = at.is_a?(String) ? (Chronic.parse(at) || 0) : (at || 0)
+        @at   = at.is_a?(String) ? (Chronic.parse(at, chronic_options) || 0) : (at || 0)
       end
 
       def self.enumerate(item, detect_cron = true)
@@ -30,10 +32,10 @@ module Whenever
         items
       end
 
-      def self.output(times, job)
+      def self.output(times, job, options = {})
         enumerate(times).each do |time|
           enumerate(job.at, false).each do |at|
-            yield new(time, job.output, at).output
+            yield new(time, job.output, at, options).output
           end
         end
       end
@@ -55,7 +57,7 @@ module Whenever
     protected
       def day_given?
         months = %w(jan feb mar apr may jun jul aug sep oct nov dec)
-        @at_given.is_a?(String) && months.any? { |m| @at_given.downcase.index(m) }
+        @at_given.is_a?(String) && (months.any? { |m| @at_given.downcase.index(m) } || @at_given[/\d\/\d/])
       end
 
       def parse_symbol

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -144,7 +144,7 @@ module Whenever
           next unless output_all || roles.any? do |r|
             job.has_role?(r)
           end
-          Whenever::Output::Cron.output(time, job) do |cron|
+          Whenever::Output::Cron.output(time, job, :chronic_options => @chronic_options) do |cron|
             cron << "\n\n"
 
             if cron[0,1] == "@"

--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -5,6 +5,10 @@ set :environment, "production"
 # Path defaults to the directory `whenever` was run from
 set :path, Whenever.path
 
+# Custom Chronic configuration for time parsing, empty by default
+# Full list of options at: https://github.com/mojombo/chronic/blob/master/lib/chronic/parser.rb
+set :chronic_options, {}
+
 # All jobs are wrapped in this template.
 # http://blog.scoutapp.com/articles/2010/09/07/rvm-and-cron-in-production
 set :job_template, "/bin/bash -l -c ':job'"

--- a/test/functional/output_at_test.rb
+++ b/test/functional/output_at_test.rb
@@ -204,4 +204,43 @@ class OutputAtTest < Whenever::TestCase
 
     assert_match '0 0 27,31 * * blahblah', output
   end
+
+  test "using custom Chronic configuration to specify time using 24 hour clock" do
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      set :chronic_options, :hours24 => true
+      every 1.day, :at => '03:00' do
+        command "blahblah"
+      end
+    file
+
+    assert_match '0 3 * * * blahblah', output
+  end
+
+  test "using custom Chronic configuration to specify date using little endian preference" do
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      set :chronic_options, :endian_precedence => :little
+      every 1.month, :at => '02/03 10:15' do
+        command "blahblah"
+      end
+    file
+
+    assert_match '15 10 2 * * blahblah', output
+  end
+
+  test "using custom Chronic configuration to specify time using 24 hour clock and date using little endian preference" do
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      set :chronic_options, :hours24 => true, :endian_precedence => :little
+      every 1.month, :at => '01/02 04:30' do
+        command "blahblah"
+      end
+    file
+
+    assert_match '30 4 1 * * blahblah', output
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,28 +8,28 @@ module Whenever::TestHelpers
       Whenever::Job.new(options)
     end
 
-    def parse_time(time = nil, task = nil, at = nil)
-      Whenever::Output::Cron.new(time, task, at).time_in_cron_syntax
+    def parse_time(time = nil, task = nil, at = nil, options = {})
+      Whenever::Output::Cron.new(time, task, at, options).time_in_cron_syntax
     end
 
     def two_hours
       "0 0,2,4,6,8,10,12,14,16,18,20,22 * * *"
     end
 
-    def assert_days_and_hours_and_minutes_equals(expected, time)
-      cron = parse_time(Whenever.seconds(2, :months), 'some task', time)
+    def assert_days_and_hours_and_minutes_equals(expected, time, options = {})
+      cron = parse_time(Whenever.seconds(2, :months), 'some task', time, options)
       minutes, hours, days, _ = cron.split(' ')
       assert_equal expected, [days, hours, minutes]
     end
 
-    def assert_hours_and_minutes_equals(expected, time)
-      cron = parse_time(Whenever.seconds(2, :days), 'some task', time)
+    def assert_hours_and_minutes_equals(expected, time, options = {})
+      cron = parse_time(Whenever.seconds(2, :days), 'some task', time, options)
       minutes, hours, _ = cron.split(' ')
       assert_equal expected, [hours, minutes]
     end
 
-    def assert_minutes_equals(expected, time)
-      cron = parse_time(Whenever.seconds(2, :hours), 'some task', time)
+    def assert_minutes_equals(expected, time, options = {})
+      cron = parse_time(Whenever.seconds(2, :hours), 'some task', time, options)
       assert_equal expected, cron.split(' ')[0]
     end
 end

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -67,6 +67,16 @@ class CronParseHoursTest < Whenever::TestCase
     assert_minutes_equals "0",  'midnight'
     assert_minutes_equals "59", '13:59'
   end
+
+  should "parse correctly when given an 'at' with minutes as a Time and custom Chronic options are set" do
+    assert_minutes_equals "15", '3:15'
+    assert_minutes_equals "15", '3:15', :chronic_options => { :hours24 => true }
+    assert_minutes_equals "15", '3:15', :chronic_options => { :hours24 => false }
+
+    assert_minutes_equals "30", '6:30'
+    assert_minutes_equals "30", '6:30', :chronic_options => { :hours24 => true }
+    assert_minutes_equals "30", '6:30', :chronic_options => { :hours24 => false }
+  end
 end
 
 class CronParseDaysTest < Whenever::TestCase
@@ -88,6 +98,17 @@ class CronParseDaysTest < Whenever::TestCase
     assert_hours_and_minutes_equals %w(0 0),   'midnight'
     assert_hours_and_minutes_equals %w(1 23),  '1:23 AM'
     assert_hours_and_minutes_equals %w(23 59), 'March 21 11:59 pM'
+  end
+
+  should "parse correctly when given an 'at' with hours, minutes as a Time and custom Chronic options are set" do
+    # first param is an array with [hours, minutes]
+    assert_hours_and_minutes_equals %w(15 15), '3:15'
+    assert_hours_and_minutes_equals %w(3 15),  '3:15', :chronic_options => { :hours24 => true }
+    assert_hours_and_minutes_equals %w(15 15), '3:15', :chronic_options => { :hours24 => false }
+
+    assert_hours_and_minutes_equals %w(6 30),  '6:30'
+    assert_hours_and_minutes_equals %w(6 30),  '6:30', :chronic_options => { :hours24 => true }
+    assert_hours_and_minutes_equals %w(6 30),  '6:30', :chronic_options => { :hours24 => false }
   end
 
   should "parse correctly when given an 'at' with hours as an Integer" do
@@ -130,6 +151,23 @@ class CronParseMonthsTest < Whenever::TestCase
     assert_days_and_hours_and_minutes_equals %w(11 23 0), 'Feb 11 11PM'
     assert_days_and_hours_and_minutes_equals %w(22 1 1), 'march 22nd at 1:01 am'
     assert_days_and_hours_and_minutes_equals %w(23 0 0), 'march 22nd at midnight' # looks like midnight means the next day
+  end
+
+  should "parse correctly when given an 'at' with days, hours, minutes as a Time and custom Chronic options are set" do
+    # first param is an array with [days, hours, minutes]
+    assert_days_and_hours_and_minutes_equals %w(22 15 45), 'February 22nd 3:45'
+    assert_days_and_hours_and_minutes_equals %w(22 15 45), '02/22 3:45'
+    assert_days_and_hours_and_minutes_equals %w(22 3 45),  'February 22nd 3:45', :chronic_options => { :hours24 => true }
+    assert_days_and_hours_and_minutes_equals %w(22 15 45), 'February 22nd 3:45', :chronic_options => { :hours24 => false }
+
+    assert_days_and_hours_and_minutes_equals %w(3 8 15), '02/03 8:15'
+    assert_days_and_hours_and_minutes_equals %w(3 8 15), '02/03 8:15', :chronic_options => { :endian_precedence => :middle }
+    assert_days_and_hours_and_minutes_equals %w(2 8 15), '02/03 8:15', :chronic_options => { :endian_precedence => :little }
+
+    assert_days_and_hours_and_minutes_equals %w(4 4 50),  '03/04 4:50', :chronic_options => { :endian_precedence => :middle, :hours24 => true }
+    assert_days_and_hours_and_minutes_equals %w(4 16 50), '03/04 4:50', :chronic_options => { :endian_precedence => :middle, :hours24 => false }
+    assert_days_and_hours_and_minutes_equals %w(3 4 50),  '03/04 4:50', :chronic_options => { :endian_precedence => :little, :hours24 => true }
+    assert_days_and_hours_and_minutes_equals %w(3 16 50), '03/04 4:50', :chronic_options => { :endian_precedence => :little, :hours24 => false }
   end
 
   should "parse correctly when given an 'at' with days as an Integer" do


### PR DESCRIPTION
This PR makes it possible for the user to specify a custom Chronic configuration for date and time parsing.

This is useful e.g. to configure Chronic to always assume a 24 hour clock:

```ruby
set :chronic_options, :hours24 => true

# By default this would run the job every day at 3pm
every 1.day, :at => '3:00' do
  runner "MyModel.nightly_archive_job"
end
```

This fixes #668.