### PR TITLE
Fix Minitest warning for `assert_equal nil`

### DIFF
--- a/test/functional/output_jobs_with_mailto_test.rb
+++ b/test/functional/output_jobs_with_mailto_test.rb
@@ -163,6 +163,6 @@ class OutputJobsWithMailtoForRolesTest < Whenever::TestCase
 
     assert_equal 'MAILTO=default@example.com', output_without_empty_line.shift
     assert_equal two_hours + " /bin/bash -l -c 'blahblah'", output_without_empty_line.shift
-    assert_equal nil, output_without_empty_line.shift
+    assert_nil output_without_empty_line.shift
   end
 end


### PR DESCRIPTION
When I run the test suite, I get the following warning:

> Use assert_nil if expecting nil from /Users/ahorvath/whenever/test/functional/output_jobs_with_mailto_test.rb:166:in `block in <class:OutputJobsWithMailtoForRolesTest>'. This will fail in MT6.

This PR is intended to fix this.