### PR TITLE
Allow literals in cron syntax

### DIFF
--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -58,8 +58,7 @@ module Whenever
 
     protected
       def day_given?
-        months = %w(jan feb mar apr may jun jul aug sep oct nov dec)
-        @at_given.is_a?(String) && (months.any? { |m| @at_given.downcase.index(m) } || @at_given[/\d\/\d/])
+        @at_given.is_a?(String) && (MONTHS.any? { |m| @at_given.downcase.index(m) } || @at_given[/\d\/\d/])
       end
 
       def parse_symbol
@@ -148,7 +147,7 @@ module Whenever
         return (timing << '1-5') * " " if string.downcase.index('weekday')
         return (timing << '6,0') * " " if string.downcase.index('weekend')
 
-        %w(sun mon tue wed thu fri sat).each_with_index do |day, i|
+        DAYS.each_with_index do |day, i|
           return (timing << i) * " " if string.downcase.index(day)
         end
 

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -3,8 +3,10 @@ require 'chronic'
 module Whenever
   module Output
     class Cron
+      DAYS = %w(sun mon tue wed thu fri sat)
+      MONTHS = %w(jan feb mar apr may jun jul aug sep oct nov dec)
       KEYWORDS = [:reboot, :yearly, :annually, :monthly, :weekly, :daily, :midnight, :hourly]
-      REGEX = /^(@(#{KEYWORDS.join '|'})|((\*?[\d\/,\-]*)\s*){5})$/
+      REGEX = /^(@(#{KEYWORDS.join '|'})|((\*?[\d\/,\-]*)\s){3}(\*?([\d\/,\-]|(#{MONTHS.join '|'}))*\s)(\*?([\d\/,\-]|(#{DAYS.join '|'}))*))$/i
 
       attr_accessor :time, :task
 

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -360,6 +360,7 @@ class CronParseRawTest < Whenever::TestCase
   should "return the same cron sytax" do
     crons = ['0 0 27-31 * *', '* * * * *', '2/3 1,9,22 11-26 1-6 *', '*/5 6-23 * * *',
              "*\t*\t*\t*\t*",
+             '7 17 * * FRI', '7 17 * * Mon-Fri', '30 12 * Jun *', '30 12 * Jun-Aug *',
              '@reboot', '@yearly', '@annually', '@monthly', '@weekly',
              '@daily', '@midnight', '@hourly']
     crons.each do |cron|


### PR DESCRIPTION
This PR allows the use of string literals for month and day-of-week in raw cron syntax. This syntax worked until faad5189afb87d0a666aeb1f76f75e1235d00695 where strings were completely disallowed. 

We don't allow arbitrary strings to avoid matching strings that were supposed to be matched by `parse_as_string`.  We also try to match only the two last fields of the timespec.
I think this also solves #704 