### PR TITLE
Use custom hook for whenever crontab update.

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -25,13 +25,15 @@ namespace :whenever do
     setup_whenever_task(fetch(:whenever_clear_flags))
   end
 
-  after "deploy:updated",  "whenever:update_crontab"
+  # [FIX ME] Override whenever default hook to execute cron tab update as needed by us.
+  after "deploy:publishing",  "whenever:update_crontab"
   after "deploy:reverted", "whenever:update_crontab"
 end
 
 namespace :load do
   task :defaults do
-    set :whenever_roles,        ->{ :db }
+    # [FIX ME] Override whenever default role and use cron role
+    set :whenever_roles,        ->{ :cron }
     set :whenever_command,      ->{ [:bundle, :exec, :whenever] }
     set :whenever_command_environment_variables, ->{ { rails_env: fetch(:whenever_environment) } }
     set :whenever_identifier,   ->{ fetch :application }


### PR DESCRIPTION
Since whenever uses release path and db role by default, new corn tab entry was being created instead of update on same cron. So, we had to override the whenever functionality to adapt to our need.

Now, by default, whenever will run in a `cron` role and the hook will get triggered after symlink.