### PR TITLE
Travis: implicit default task is bundle exec rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-script: bundle exec rake
 
 before_install:
   - gem install bundler
@@ -17,3 +16,6 @@ gemfile:
   - Gemfile
   - gemfiles/activesupport4.1.gemfile
   - gemfiles/activesupport4.2.gemfile
+env:
+  global:
+    - JRUBY_OPTS=--debug


### PR DESCRIPTION
This PR

- deletes the implicit `bundle exec rake` script from the Travis config
- adds a JRUBY_OPTS, in order to try to get better code coverage information on JRuby