### PR TITLE
Add support for mapping Range objects to cron range syntax

### DIFF
--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -152,7 +152,7 @@ module Whenever
 
       def range_or_integer(at, valid_range, name)
         must_be_between = "#{name} must be between #{valid_range.min}-#{valid_range.max}"
-        unless at.is_a?(Range)
+        if !at.is_a?(Range)
           raise ArgumentError, "#{must_be_between}, #{at} given" unless valid_range.include?(at)
           return at
         end

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -96,15 +96,13 @@ module Whenever
             timing[0] = comma_separated_timing(minute_frequency, 59, @at || 0)
           when Whenever.seconds(1, :hour)...Whenever.seconds(1, :day)
             hour_frequency = (@time / 60 / 60).round
-            timing[0] = @at.is_a?(Time) ? @at.min : @at
+            timing[0] = @at.is_a?(Time) ? @at.min : range_or_integer(@at, 0..59, 'Minute')
             timing[1] = comma_separated_timing(hour_frequency, 23)
-            raise ArgumentError, "Minute must be between 0-59, #{timing[0]} given" unless (0..59).include?(timing[0])
           when Whenever.seconds(1, :day)...Whenever.seconds(1, :month)
             day_frequency = (@time / 24 / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min  : 0
-            timing[1] = @at.is_a?(Time) ? @at.hour : @at
+            timing[1] = @at.is_a?(Time) ? @at.hour : range_or_integer(@at, 0..23, 'Hour')
             timing[2] = comma_separated_timing(day_frequency, 31, 1)
-            raise ArgumentError, "Hour must be between 0-23, #{timing[1]} given" unless (0..23).include?(timing[1])
           when Whenever.seconds(1, :month)...Whenever.seconds(1, :year)
             month_frequency = (@time / 30 / 24 / 60 / 60).round
             timing[0] = @at.is_a?(Time) ? @at.min  : 0
@@ -112,10 +110,9 @@ module Whenever
             timing[2] = if @at.is_a?(Time)
               day_given? ? @at.day : 1
             else
-              @at.zero? ? 1 : @at
+              @at == 0 ? 1 : range_or_integer(@at, 1..31, 'Day')
             end
             timing[3] = comma_separated_timing(month_frequency, 12, 1)
-            raise ArgumentError, "Day must be between 1-31, #{timing[2]} given" unless (1..31).include?(timing[2])
           when Whenever.seconds(1, :year)
             timing[0] = @at.is_a?(Time) ? @at.min  : 0
             timing[1] = @at.is_a?(Time) ? @at.hour : 0
@@ -127,9 +124,8 @@ module Whenever
             timing[3] = if @at.is_a?(Time)
               day_given? ? @at.month : 1
             else
-              @at.zero? ? 1 : @at
+              @at == 0 ? 1 : range_or_integer(@at, 1..12, 'Month')
             end
-            raise ArgumentError, "Month must be between 1-12, #{timing[3]} given" unless (1..12).include?(timing[3])
           else
             return parse_as_string
         end
@@ -152,6 +148,17 @@ module Whenever
         end
 
         raise ArgumentError, "Couldn't parse: #{@time}"
+      end
+
+      def range_or_integer(at, valid_range, name)
+        must_be_between = "#{name} must be between #{valid_range.min}-#{valid_range.max}"
+        unless at.is_a?(Range)
+          raise ArgumentError, "#{must_be_between}, #{at} given" unless valid_range.include?(at)
+          return at
+        end
+        raise ArgumentError, "#{must_be_between}, #{at.min} given" unless valid_range.include?(at.min)
+        raise ArgumentError, "#{must_be_between}, #{at.max} given" unless valid_range.include?(at.max)
+        "#{at.min}-#{at.max}"
       end
 
       def comma_separated_timing(frequency, max, start = 0)

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -78,6 +78,10 @@ class CronParseHoursTest < Whenever::TestCase
     assert_minutes_equals "30", '6:30', :chronic_options => { :hours24 => false }
   end
 
+  should "parse correctly when given an 'at' with minutes as a Range" do
+    assert_minutes_equals "15-30", 15..30
+  end
+
   should "raise an exception when given an 'at' with an invalid minute value" do
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :hour), nil, 60)
@@ -85,6 +89,14 @@ class CronParseHoursTest < Whenever::TestCase
 
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :hour), nil, -1)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :hour), nil, 0..60)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :hour), nil, -1..59)
     end
   end
 end
@@ -130,6 +142,10 @@ class CronParseDaysTest < Whenever::TestCase
     assert_hours_and_minutes_equals %w(23 0), 23
   end
 
+  should "parse correctly when given an 'at' with hours as a Range" do
+    assert_hours_and_minutes_equals %w(3-23 0), 3..23
+  end
+
   should "raise an exception when given an 'at' with an invalid hour value" do
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :day), nil, 24)
@@ -137,6 +153,14 @@ class CronParseDaysTest < Whenever::TestCase
 
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :day), nil, -1)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :day), nil, 0..24)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :day), nil, -1..23)
     end
   end
 end
@@ -197,6 +221,10 @@ class CronParseMonthsTest < Whenever::TestCase
     assert_days_and_hours_and_minutes_equals %w(29 0 0), 29
   end
 
+  should "parse correctly when given an 'at' with days as a Range" do
+    assert_days_and_hours_and_minutes_equals %w(1-7 0 0), 1..7
+  end
+
   should "raise an exception when given an 'at' with an invalid day value" do
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :month), nil, 32)
@@ -204,6 +232,14 @@ class CronParseMonthsTest < Whenever::TestCase
 
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :month), nil, -1)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :month), nil, 0..30)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :month), nil, 1..32)
     end
   end
 end
@@ -254,6 +290,10 @@ class CronParseYearTest < Whenever::TestCase
     assert_months_and_days_and_hours_and_minutes_equals %w(12 1 0 0), 12
   end
 
+  should "parse correctly when given an 'at' with month as a Range" do
+    assert_months_and_days_and_hours_and_minutes_equals %w(1-3 1 0 0), 1..3
+  end
+
   should "raise an exception when given an 'at' with an invalid month value" do
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :year), nil, 13)
@@ -261,6 +301,14 @@ class CronParseYearTest < Whenever::TestCase
 
     assert_raises ArgumentError do
       parse_time(Whenever.seconds(1, :year), nil, -1)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :year), nil, 0..12)
+    end
+
+    assert_raises ArgumentError do
+      parse_time(Whenever.seconds(1, :year), nil, 1..13)
     end
   end
 end


### PR DESCRIPTION
Cron has syntax for defining ranges with hyphens, but AFAICT whenever does not support any constructs which map to that syntax. For example, defining a command to run every hour but excluding specific hours can be implemented like this in whenever:

```ruby
every 1.day, at: 4..23
```

Which maps to the following verbose cron syntax:

    0 4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23 * * *

It would be much nicer if instead it was mapped to a range expression, like this:

    0 4-23 * * *

Much easier to spot check. A common use case for this would be to prevent certain hourly commands from running during a maintenance/backup window.
