### PR TITLE
Avoid overriding default_env in capistrano

### DIFF
--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -44,7 +44,7 @@ namespace :load do
   task :defaults do
     set :whenever_roles,        ->{ :db }
     set :whenever_command,      ->{ [:bundle, :exec, :whenever] }
-    set :whenever_command_environment_variables, ->{ fetch(:default_env).merge!(rails_env: fetch(:whenever_environment)) }
+    set :whenever_command_environment_variables, ->{ fetch(:default_env).merge(rails_env: fetch(:whenever_environment)) }
     set :whenever_identifier,   ->{ fetch :application }
     set :whenever_environment,  ->{ fetch :rails_env, fetch(:stage, "production") }
     set :whenever_variables,    ->{ "environment=#{fetch :whenever_environment}" }


### PR DESCRIPTION
Commands always include RAILS_ENV in environment variables after executed  `whenever:update_crontab'. I think It's unintended for not rails task. Depending on the user's privileges, below error occurs,

> stderr: sudo: sorry, you are not allowed to set the following environment variables: RAILS_ENV

It isn't secure to change sudoer's setting for avoiding it. `whenever_command_environment_variables` is the variable for whenever only, so the side effects that affect other tasks should be eliminated.