### PR TITLE
Use `current_path` as a fallback for whenever_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Bugfix: Avoid modifying Capistrano `default_env` when setting the whenever environment. [ta1kt0me](https://github.com/javan/whenever/pull/728)
 
+* Enable to execute whenever's task independently without setting :release_path or :whenever_path [ta1kt0me](https://github.com/javan/whenever/pull/729)
+
 ### 0.10.0 / November 19, 2017
 
 * Modify wheneverize to allow for the creating of 'config' directory when not present

--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -51,6 +51,6 @@ namespace :load do
     set :whenever_load_file,    ->{ nil }
     set :whenever_update_flags, ->{ "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables}" }
     set :whenever_clear_flags,  ->{ "--clear-crontab #{fetch :whenever_identifier}" }
-    set :whenever_path,         ->{ fetch :release_path }
+    set :whenever_path,         ->{ release_path }
   end
 end


### PR DESCRIPTION
There is a problem that nil is set to `whenever_path` in executing the whenever task directly via Capistrano. I think calling `release_path` is useful in the case because it's enough to set `deploy_to`only.