### PR TITLE
clearer ArgumentError in:re @benlangfeld (#726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Bugfix: Avoid modifying Capistrano `default_env` when setting the whenever environment. [ta1kt0me](https://github.com/javan/whenever/pull/728)
 
+* Clearer ArgumentError re: inability to escape trailing spaces [kamillamagna](https://github.com/javan/whenever/pull/730)
+
 ### 0.10.0 / November 19, 2017
 
 * Modify wheneverize to allow for the creating of 'config' directory when not present

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -147,7 +147,7 @@ module Whenever
           return (timing << i) * " " if string.downcase.index(day)
         end
 
-        raise ArgumentError, "Couldn't parse: #{@time}"
+        raise ArgumentError, "Couldn't parse: \"#{@time}\""
       end
 
       def range_or_integer(at, valid_range, name)


### PR DESCRIPTION
> The backward compatability is something we have to live with until we cut v1.0, but we can do a better job with the error message by calling #inspect on the value so it would read:
>
> `ArgumentError: Couldn't parse: "47 */6 * * * "`
>
> Is this something you would be prepared to submit a PR for?