### PR TITLE
Use class_eval to add behaviour to Numeric

### DIFF
--- a/lib/whenever/numeric.rb
+++ b/lib/whenever/numeric.rb
@@ -1,4 +1,4 @@
-class Numeric
+Numeric.class_eval do
   def respond_to?(method, include_private = false)
     super || Whenever::NumericSeconds.public_method_defined?(method)
   end


### PR DESCRIPTION
When reopening classes, it's safer to use `Class.class_eval` since it ensures the original class will be loaded first.