### PR TITLE
Call inspect on the time that couldn't be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Enable to execute whenever's task independently without setting :release_path or :whenever_path [ta1kt0me](https://github.com/javan/whenever/pull/729)
 
+* Make error message clearer when parsing cron syntax fails due to a trailing space [ignisf](https://github.com/javan/whenever/pull/744)
+
 ### 0.10.0 / November 19, 2017
 
 * Modify wheneverize to allow for the creating of 'config' directory when not present

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -147,7 +147,7 @@ module Whenever
           return (timing << i) * " " if string.downcase.index(day)
         end
 
-        raise ArgumentError, "Couldn't parse: #{@time}"
+        raise ArgumentError, "Couldn't parse: #{@time.inspect}"
       end
 
       def range_or_integer(at, valid_range, name)


### PR DESCRIPTION
This commit makes the error message clearer when parsing fails due to a trailing
space in a string with cron syntax.

Fixes #726