### PR TITLE
Fix typo in a comment

### DIFF
--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -102,7 +102,7 @@ module Whenever
         exit(1)
       end
 
-      # If an existing identier block is found, replace it with the new cron entries
+      # If an existing identifier block is found, replace it with the new cron entries
       if read_crontab =~ Regexp.new("^#{comment_open_regex}\s*$") && read_crontab =~ Regexp.new("^#{comment_close_regex}\s*$")
         # If the existing crontab file contains backslashes they get lost going through gsub.
         # .gsub('\\', '\\\\\\') preserves them. Go figure.


### PR DESCRIPTION
Typo is not good even if it's in comment;
When your editor's autocompletion collects this typo, you might
mis-type the option symbol :identifier to :identier...