### PR TITLE
Identifier in schedule

### DIFF
--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -8,8 +8,12 @@ require 'whenever/output_redirection'
 require 'whenever/os'
 
 module Whenever
+  def self.job_list(options)
+    Whenever::JobList.new(options)
+  end
+
   def self.cron(options)
-    Whenever::JobList.new(options).generate_cron_output
+    job_list(options).generate_cron_output
   end
 
   def self.seconds(number, units)

--- a/lib/whenever/command_line.rb
+++ b/lib/whenever/command_line.rb
@@ -102,7 +102,7 @@ module Whenever
         exit(1)
       end
 
-      # If an existing identier block is found, replace it with the new cron entries
+      # If an existing identifier block is found, replace it with the new cron entries
       if read_crontab =~ Regexp.new("^#{comment_open_regex}\s*$") && read_crontab =~ Regexp.new("^#{comment_close_regex}\s*$")
         # If the existing crontab file contains backslashes they get lost going through gsub.
         # .gsub('\\', '\\\\\\') preserves them. Go figure.

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -37,7 +37,7 @@ module Whenever
       @set_variables.has_key?(name) ? @set_variables[name] : super
     end
 
-    def self.respond_to?(name, include_private = false)
+    def respond_to?(name, include_private = false)
       @set_variables.has_key?(name) || super
     end
 

--- a/test/functional/command_line_test.rb
+++ b/test/functional/command_line_test.rb
@@ -1,12 +1,23 @@
 require 'test_helper'
 
+class WheneverJobListMock
+  def initialize(task)
+    @task = task
+  end
+
+  def generate_cron_output
+    @task
+  end
+end
+
 class CommandLineWriteTest < Whenever::TestCase
   setup do
     Time.stubs(:now).returns(Time.new(2017, 2, 24, 16, 21, 30, '+01:00'))
     File.expects(:exist?).with('config/schedule.rb').returns(true)
     @command = Whenever::CommandLine.new(:write => true, :identifier => 'My identifier')
     @task = "#{two_hours} /my/command"
-    Whenever.expects(:cron).returns(@task)
+    job_list_mock = WheneverJobListMock.new(@task)
+    Whenever.expects(:job_list).returns(job_list_mock)
   end
 
   should "output the cron job with identifier blocks" do
@@ -31,7 +42,8 @@ class CommandLineUpdateTest < Whenever::TestCase
     File.expects(:exist?).with('config/schedule.rb').returns(true)
     @command = Whenever::CommandLine.new(:update => true, :identifier => 'My identifier')
     @task = "#{two_hours} /my/command"
-    Whenever.expects(:cron).returns(@task)
+    job_list_mock = WheneverJobListMock.new(@task)
+    Whenever.expects(:job_list).returns(job_list_mock)
   end
 
   should "add the cron to the end of the file if there is no existing identifier block" do
@@ -301,6 +313,7 @@ class CommandLineUpdateWithNoIdentifierTest < Whenever::TestCase
   setup do
     Time.stubs(:now).returns(Time.new(2017, 2, 24, 16, 21, 30, '+01:00'))
     File.expects(:exist?).with('config/schedule.rb').returns(true)
+    Whenever.expects(:job_list).returns(Object.new)
     Whenever::CommandLine.any_instance.expects(:default_identifier).returns('DEFAULT')
     @command = Whenever::CommandLine.new(:update => true)
   end

--- a/test/functional/command_line_test.rb
+++ b/test/functional/command_line_test.rb
@@ -469,3 +469,35 @@ EXISTING_CRON
     assert_equal existing, @command.send(:prepare, existing)
   end
 end
+
+class IdentifierInSchedule < Whenever::TestCase
+  setup do
+    Time.stubs(:now).returns(Time.new(2017, 2, 24, 16, 21, 30, '+01:00'))
+    @test_schedule_path = File.expand_path('../test-schedules/schedule.rb', __dir__)
+  end
+
+  should "use schedule.rb's identifier" do
+    command = Whenever::CommandLine.new(update: true, file: @test_schedule_path)
+    expected = <<-EXPECTED
+# Begin Whenever generated tasks for: Identifier Defined In Schedule.rb at: 2017-02-24 16:21:30 +0100
+
+# End Whenever generated tasks for: Identifier Defined In Schedule.rb at: 2017-02-24 16:21:30 +0100
+EXPECTED
+
+    assert_equal expected, command.send(:whenever_cron)
+  end
+
+  should "user commandline option over in-schedule option" do
+    command = Whenever::CommandLine.new(
+      update: true,
+      file: @test_schedule_path,
+      identifier: 'Identifier From CommandLine'
+    )
+    expected = <<-EXPECTED
+# Begin Whenever generated tasks for: Identifier From CommandLine at: 2017-02-24 16:21:30 +0100
+
+# End Whenever generated tasks for: Identifier From CommandLine at: 2017-02-24 16:21:30 +0100
+EXPECTED
+    assert_equal expected, command.send(:whenever_cron)
+  end
+end

--- a/test/test-schedules/schedule.rb
+++ b/test/test-schedules/schedule.rb
@@ -1,0 +1,2 @@
+
+set :identifier, 'Identifier Defined In Schedule.rb'


### PR DESCRIPTION
Implements #753 , so, closes #753 .

With this PR, one can set identifier by writing following in the `schedule.rb`.

```ruby
set :identifier, 'Some identifier'
```

If no identifier is given from commandline, this value will be used for the identifier; if one is given from commandline, commandline's value will be used.

If commandline does not give identifier and also not set in `schedule.rb`, then the default value of full path to `schedule.rb` will be used.

This PR includes #756 and #757 , so, closes #756 and #757 .
