### PR TITLE
Splat whenever_roles when passing to roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### develop
 
+* Bugfix: Splat `whenever_roles` when passing to `roles` to allow definition of multiple whenever roles [samuelokrent](https://github.com/javan/whenever/pull/777)
+
 ### 0.11.0 / April 23, 2019
 
 * Add support for mapping Range objects to cron range syntax [Tim Craft](https://github.com/javan/whenever/pull/725)

--- a/lib/whenever/capistrano/v3/tasks/whenever.rake
+++ b/lib/whenever/capistrano/v3/tasks/whenever.rake
@@ -2,7 +2,7 @@ namespace :whenever do
   def setup_whenever_task(*args, &block)
     args = Array(fetch(:whenever_command)) + args
 
-    on roles fetch(:whenever_roles) do |host|
+    on roles *fetch(:whenever_roles) do |host|
       args_for_host = block_given? ? args + Array(yield(host)) : args
       within fetch(:whenever_path) do
         with fetch(:whenever_command_environment_variables) do


### PR DESCRIPTION
Setting `whenever_roles` to an array of multiple roles in deploy.rb like:

`set :whenever_roles, -> { [:role_1, :role_2] }`

in a capistrano deploy results in an error like:

```
NoMethodError: undefined method `to_sym' for [:role_1, :role_2]:Array
Did you mean?  to_s
               to_yaml
               to_set
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:25:in `each'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:25:in `flat_map'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:25:in `required'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:15:in `roles'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers/role_filter.rb:11:in `for'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers.rb:45:in `fetch_roles'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration/servers.rb:18:in `roles_for'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/configuration.rb:45:in `roles_for'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/dsl/env.rb:43:in `roles'
/var/lib/gems/2.3.0/gems/whenever-0.9.4/lib/whenever/tasks/whenever.rake:5:in `setup_whenever_task'
/var/lib/gems/2.3.0/gems/whenever-0.9.4/lib/whenever/tasks/whenever.rake:17:in `block (2 levels) in <top (required)>'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/dsl.rb:14:in `invoke'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/dsl/task_enhancements.rb:11:in `block in after'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/dsl.rb:14:in `invoke'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/tasks/framework.rake:64:in `block (2 levels) in <top (required)>'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/tasks/framework.rake:63:in `each'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/tasks/framework.rake:63:in `block in <top (required)>'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/lib/capistrano/application.rb:12:in `run'
/var/lib/gems/2.3.0/gems/capistrano-3.0.1/bin/cap:3:in `<top (required)>'
/usr/local/bin/cap:23:in `load'
/usr/local/bin/cap:23:in `<main>'
Tasks: TOP => whenever:update_crontab
(See full trace by running task with --trace)
```

It appears `roles` expects a list of arguments, not an array.

