### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Other commonly used options include:
 ```sh
 $ whenever --user app # set a user as which to install the crontab
 $ whenever --load-file config/my_schedule.rb # set the schedule file
-$ whenever --crontab-command 'sudo crontab` # override the crontab command
+$ whenever --crontab-command 'sudo crontab' # override the crontab command
 ```
 
 You can list installed cron jobs using `crontab -l`.


### PR DESCRIPTION
Fix typo in README.md(#775 )

I can not execute the command by copy and paste now.
This fix makes it possible to execute just by copying and pasting the command in README.md.