### PR TITLE
Only install bundler if it isn't present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 before_install:
-  - gem install bundler
+  - gem list -i bundler || gem install bundler
   - unset _JAVA_OPTIONS
 rvm:
   - 1.9.3


### PR DESCRIPTION
On some rubies which require bundler < 2.0, Travis already installs it, meaning we don't have to do so ourselves, where we try and install 2.x.