### PR TITLE
add ability to add&update cron jobs from rails model&controllers

### DIFF
--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -8,6 +8,14 @@ require 'whenever/output_redirection'
 require 'whenever/os'
 
 module Whenever
+  def self.add_cron(task, id)
+    options = {}
+    options[:string] = task
+    options[:update] = true
+    options[:identifier] = id
+    Whenever::CommandLine.execute(options)
+  end
+
   def self.cron(options)
     Whenever::JobList.new(options).generate_cron_output
   end

--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -16,6 +16,13 @@ module Whenever
     Whenever::CommandLine.execute(options)
   end
 
+  def self.remove_cron(id)
+    options = {}
+    options[:clear] = true
+    options[:identifier] = id
+    Whenever::CommandLine.execute(options)
+  end
+
   def self.cron(options)
     Whenever::JobList.new(options).generate_cron_output
   end


### PR DESCRIPTION
in gemfile
add gem 'whenever'  without require: false 
then in controllers and models add jobs to the crontab by the following 
```
task = %{
every 2.hours do 
command 'echo "test"'
end
}
Whenever.add_cron(task, identifier)
```