### PR TITLE
Clarify in README that tasks are run in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Run `whenever --help` for a complete list of options for selecting the schedule 
 
 ```ruby
 every 3.hours do # 1.minute 1.day 1.week 1.month 1.year is also supported
+  # the following tasks are run in parallel (not in sequence)
   runner "MyModel.some_process"
   rake "my:rake:task"
   command "/usr/bin/my_great_command"


### PR DESCRIPTION
I suggest that you make it clear in the README that all tasks, even inside the same block, are run in parallel. That is not clear: if you see a sequence of commands inside the same block, you would expect that it is a sequence of commands (e.g. `&&`).