### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ The default job types that ship with Whenever are defined like so:
 
 ```ruby
 job_type :command, ":task :output"
-job_type :rake,    "cd :path && :environment_variable=:environment bundle exec rake :task --silent :output"
-job_type :runner,  "cd :path && bin/rails runner -e :environment ':task' :output"
-job_type :script,  "cd :path && :environment_variable=:environment bundle exec script/:task :output"
+job_type :rake,    "cd :path && :environment_variable=:environment :bundle_command rake :task --silent :output"
+job_type :script,  "cd :path && :environment_variable=:environment :bundle_command script/:task :output"
+job_type :runner,  "cd :path && :bundle_command :runner_command -e :environment ':task' :output"
 ```
 
 Pre-Rails 3 apps and apps that don't use Bundler will redefine the `rake` and `runner` jobs respectively to function correctly.


### PR DESCRIPTION
Update the default job types displayed on README.md as they are not representing what they really are anymore and can be confusing.