### PR TITLE
Clarify options and warn about overwriting

### DIFF
--- a/bin/whenever
+++ b/bin/whenever
@@ -8,15 +8,21 @@ options = {}
 
 OptionParser.new do |opts|
   opts.banner = "Usage: whenever [options]"
-  opts.on('-i', '--update-crontab [identifier]', 'Default: full path to schedule.rb file') do |identifier|
+  opts.on('-i', '--update-crontab [schedule]',
+          'Install the schedule to crontab.',
+          '  Default: full path to schedule.rb file') do |identifier|
     options[:update] = true
     options[:identifier] = identifier if identifier
   end
-  opts.on('-w', '--write-crontab [identifier]', 'Default: full path to schedule.rb file') do |identifier|
+  opts.on('-w', '--write-crontab [schedule]',
+          'Clear current crontab, and overwrite it with only the given schedule.',
+          '  Default: full path to schedule.rb file') do |identifier|
      options[:write] = true
      options[:identifier] = identifier if identifier
   end
-  opts.on('-c', '--clear-crontab [identifier]') do |identifier|
+  opts.on('-c', '--clear-crontab [schedule]',
+          'Uninstall the schedule from crontab.',
+          '  Default: full path to schedule.rb file') do |identifier|    
     options[:clear] = true
     options[:identifier] = identifier if identifier
   end


### PR DESCRIPTION
This might help new users select the desired operation, and make it known that some operations are potentially dangerous.
- Change `[identifier]` verbage to `[schedule]`
- Add notes about overwriting existing crontabs


Today I was exploring this gem for the first time and the existing help page led me to think that `-w` was the correct option to start with. I ended up overwriting my existing crontab, which was quite unexpected.

I thought it would be helpful to clarify some points in the help banner.

Current banner:

```
Usage: whenever [options]
    -i [identifier],                 Default: full path to schedule.rb file
        --update-crontab
    -w, --write-crontab [identifier] Default: full path to schedule.rb file
    -c, --clear-crontab [identifier]
    -s, --set [variables]            Example: --set 'environment=staging&path=/my/sweet/path'
    -f, --load-file [schedule file]  Default: config/schedule.rb
    -u, --user [user]                Default: current user
    -k, --cut [lines]                Cut lines from the top of the cronfile
    -r, --roles [role1,role2]        Comma-separated list of server roles to generate cron jobs for
    -x, --crontab-command [command]  Default: crontab
    -v, --version

```


Banner after this change:

```
Usage: whenever [options]
    -i, --update-crontab [schedule]  Install the schedule to crontab.
                                       Default: full path to schedule.rb file
    -w, --write-crontab [schedule]   Clear current crontab, and overwrite it with only the given schedule.
                                       Default: full path to schedule.rb file
    -c, --clear-crontab [schedule]   Uninstall the schedule from crontab.
                                       Default: full path to schedule.rb file
    -s, --set [variables]            Example: --set 'environment=staging&path=/my/sweet/path'
    -f, --load-file [schedule file]  Default: config/schedule.rb
    -u, --user [user]                Default: current user
    -k, --cut [lines]                Cut lines from the top of the cronfile
    -r, --roles [role1,role2]        Comma-separated list of server roles to generate cron jobs for
    -x, --crontab-command [command]  Default: crontab
    -v, --version
```


I'm still a little confused about why there seems to be options for `-f` and `[identifier]` which seem to result in similar concepts. If this can be clarified, I think it would also be helpful. I feel that the correct way to specify an alternative schedule should be `whenever -i -f 'myschedule.rb'`. It would reduce the confusion and complexity of the `-iwc` options.

Is there anything I've misunderstood about Whenever while making this edit? Any other additions to consider?

_**Edit**:_ Updated correct "current banner". Sorry, I had one of my previous attempts at cleaning up the banner as the example current banner.