### PR TITLE
Set environment based on RAILS_ENV if present

### DIFF
--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -1,7 +1,8 @@
 # Environment variable defaults to RAILS_ENV
 set :environment_variable, "RAILS_ENV"
-# Environment defaults to production
-set :environment, "production"
+# Environment defaults to the value of RAILS_ENV in the current environment if
+# it's set or production otherwise
+set :environment, ENV.fetch("RAILS_ENV", "production")
 # Path defaults to the directory `whenever` was run from
 set :path, Whenever.path
 

--- a/test/functional/output_default_defined_jobs_test.rb
+++ b/test/functional/output_default_defined_jobs_test.rb
@@ -209,6 +209,20 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
     assert_match two_hours + ' cd /some/other/path && RAILS_ENV=production bundle exec rake blahblah --silent', output
   end
 
+  test "A rake command that uses the default environment variable when RAILS_ENV is set" do
+    ENV.expects(:fetch).with("RAILS_ENV", "production").returns("development")
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      set :path, '/my/path'
+      every 2.hours do
+        rake "blahblah"
+      end
+    file
+
+    assert_match two_hours + ' cd /my/path && RAILS_ENV=development bundle exec rake blahblah --silent', output
+  end
+
   test "A rake command that sets the environment variable" do
     output = Whenever.cron \
     <<-file


### PR DESCRIPTION
Fixes #660

This changes whenever to get set the environment for cron jobs based off
the currently set RAILS_ENV environment variable. If RAILS_ENV is not
set it defaults to production to be backwards compatible with the
previous behaviour.