### PR TITLE
Allows special characters #,L,W,?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### unreleased
 
+* Allows special characters like L, W, # and ?, which are natively supported by corn
+
 * Add note in README that cron is generated with the current user. [Raquel Queiroz]
 
 ### 1.0.0 / Jun 13, 2019

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -6,7 +6,7 @@ module Whenever
       DAYS = %w(sun mon tue wed thu fri sat)
       MONTHS = %w(jan feb mar apr may jun jul aug sep oct nov dec)
       KEYWORDS = [:reboot, :yearly, :annually, :monthly, :weekly, :daily, :midnight, :hourly]
-      REGEX = /^(@(#{KEYWORDS.join '|'})|((\*?[\d\/,\-]*)\s){3}(\*?([\d\/,\-]|(#{MONTHS.join '|'}))*\s)(\*?([\d\/,\-]|(#{DAYS.join '|'}))*))$/i
+      REGEX = /^(@(#{KEYWORDS.join '|'})|((\*?[\d\/,\-]*)\s){2}((\*|\?)?[\d\/,\-LW]*)\s(\*?([\d\/,\-]|(#{MONTHS.join '|'}))*\s)(\*?([\d\/,\-\#\?L]|(#{DAYS.join '|'}))*))$/i
 
       attr_accessor :time, :task
 

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -408,6 +408,7 @@ class CronParseRawTest < Whenever::TestCase
   should "return the same cron sytax" do
     crons = ['0 0 27-31 * *', '* * * * *', '2/3 1,9,22 11-26 1-6 *', '*/5 6-23 * * *',
              "*\t*\t*\t*\t*",
+             '15 10 15 * ?', '15 10 ? * 6L', '15 10 ? * 6#3', '0 12 LW * ?',
              '7 17 * * FRI', '7 17 * * Mon-Fri', '30 12 * Jun *', '30 12 * Jun-Aug *',
              '@reboot', '@yearly', '@annually', '@monthly', '@weekly',
              '@daily', '@midnight', '@hourly']


### PR DESCRIPTION
I need to run something like 

```
"0 12 ? * 6#1"
# Every month on the first Friday of the Month, at noon
```

 in the datetime. This is not supported by the current REGEX. So, I am sending a PR to add the support.

Thank you.

Reference: https://www.netiq.com/documentation/cloud-manager-2-5/ncm-reference/?page=/documentation/cloud-manager-2-5/ncm-reference/data/bexyssf.html

