### PR TITLE
Pseudo-Randomize "every hour" and "every day"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Run `whenever --help` for a complete list of options for selecting the schedule 
 ### Example schedule.rb file
 
 ```ruby
+# randomize all :hour- and :day-jobs, when no specific at-time is given.
+# This avoids hourly jobs starting at the same time.
+# set :randomize, true
+
 every 3.hours do # 1.minute 1.day 1.week 1.month 1.year is also supported
   # the following tasks are run in parallel (not in sequence)
   runner "MyModel.some_process"
@@ -68,6 +72,10 @@ every 1.day, at: ['4:30 am', '6:00 pm'] do
 end
 
 every :hour do # Many shortcuts available: :hour, :day, :month, :year, :reboot
+  runner "SomeModel.ladeeda"
+end
+
+every :hour, randomize: true do # each hour, but at random minute
   runner "SomeModel.ladeeda"
 end
 

--- a/lib/whenever/cron.rb
+++ b/lib/whenever/cron.rb
@@ -20,7 +20,7 @@ module Whenever
         @at_given = at
         @time = time
         @task = task
-        at    = Cron.randomize_at_by_task(at, time, task) if options[:randomize]
+        at    = Cron.randomize_at_by_task(at, time, options[:task]) if options[:randomize]
         @at   = at.is_a?(String) ? (Chronic.parse(at, chronic_options) || 0) : (at || 0)
       end
 
@@ -50,7 +50,7 @@ module Whenever
       # pseudo-random: same at for same task, useful for debugging across several deploys
       def self.randomize_at_by_task(at, time, task)
         return at unless at.nil?
-        
+
         # atm, the randomizing-feature works only for symbols :hour and :day
         # return at unless time.is_a?(Symbol) && [:hour, :day].include?(time)
         case time

--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -2,7 +2,7 @@ require 'shellwords'
 
 module Whenever
   class Job
-    attr_reader :at, :roles, :mailto
+    attr_reader :at, :roles, :mailto, :options
 
     def initialize(options = {})
       @options = options

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -142,7 +142,7 @@ module Whenever
         next unless roles.empty? || roles.any? do |r|
           job.has_role?(r)
         end
-        Whenever::Output::Cron.output(time, job, :chronic_options => @chronic_options) do |cron|
+        Whenever::Output::Cron.output(time, job, job.options.merge(:chronic_options => @chronic_options)) do |cron|
           cron << "\n\n"
 
           if cron[0,1] == "@"

--- a/test/functional/output_random_at_test.rb
+++ b/test/functional/output_random_at_test.rb
@@ -15,6 +15,16 @@ class OutputRandomAtTest < Whenever::TestCase
     output = Whenever.cron \
     <<-file
       set :job_template, nil
+      set :randomize, true
+      every :day do
+        runner "blahblah"
+      end
+    file
+    assert_match(/\A34 2 * * */, output)
+
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
       every :day, randomize: true do
         command "blah"
       end

--- a/test/functional/output_random_at_test.rb
+++ b/test/functional/output_random_at_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class OutputRandomAtTest < Whenever::TestCase
+  test "pseudo random at for hour and day" do
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      set :randomize, true
+      every :day do
+        command "blahblah"
+      end
+    file
+    assert_match '34 2 * * * blahblah', output
+
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      every :day, randomize: true do
+        command "blah"
+      end
+    file
+    assert_match '47 5 * * * blah', output
+
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      set :randomize, true
+      every :hour do
+        command "blahblah"
+      end
+    file
+    assert_match '34 * * * * blahblah', output
+
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      every :hour, randomize: true do
+        command "blah"
+      end
+    file
+    assert_match '47 * * * * blah', output
+  end
+end


### PR DESCRIPTION
This replaces #596  , but the idea is the same:
"If you use the Symbol-Shortcut (:hour or :day at the moment) and leave the at-argument blank, the exact time of execution will be randomized.
This can reduce the load, when multiple jobs run hourly, for example."

Now its using a pseudo-random schedule-time, which means, that the same command will result in the same time. (So that times will not change between deploys for example)