### PR TITLE
job_list self.respond_to? responds to empty @set_variables

### DIFF
--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -38,7 +38,9 @@ module Whenever
     end
 
     def self.respond_to?(name, include_private = false)
-      @set_variables.has_key?(name) || super
+      if @set_variables
+        @set_variables.has_key?(name)
+      end || super
     end
 
     def env(variable, value)


### PR DESCRIPTION
Since version 1.4.3 (https://github.com/ruby/irb/compare/v1.4.3...master), irb ruby gem (https://github.com/ruby/irb) is calling directly "respond_to?" method on all included code inside a project. That change makes all code included in a project having that method crashing if implementing it in a way not always returning a true or false, like described in the ruby doc: https://www.rubydoc.info/stdlib/core/Object:respond_to%3F

So, I just wanted to propose that simple change which would prevent that (and maybe) other situations, now always returning a value. I've not used the Ruby '&' in order to be retro-compatible with pre-2.3 ruby versions, in case.