### PR TITLE
Leveraging RAILS_ENV already present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Add note in README that cron is generated with the current user. [Raquel Queiroz]
 
-*  Set the environment for cron jobs based off the currently set RAILS_ENV env variable. If RAILS_ENV is not set it defaults to production
+* Set the environment for cron jobs based off the currently set RAILS_ENV env variable. If RAILS_ENV is not set it defaults to production
 
 ### 1.0.0 / Jun 13, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Add note in README that cron is generated with the current user. [Raquel Queiroz]
 
+### 1.0.1 / Jan 21, 2023
+
+*  Set the environment for cron jobs based off the currently set RAILS_ENV env variable. If RAILS_ENV is not set it defaults to production
+
 ### 1.0.0 / Jun 13, 2019
 
 * First stable release per SemVer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 * Add note in README that cron is generated with the current user. [Raquel Queiroz]
 
-### 1.0.1 / Jan 21, 2023
-
 *  Set the environment for cron jobs based off the currently set RAILS_ENV env variable. If RAILS_ENV is not set it defaults to production
 
 ### 1.0.0 / Jun 13, 2019

--- a/lib/whenever/setup.rb
+++ b/lib/whenever/setup.rb
@@ -1,7 +1,8 @@
 # Environment variable defaults to RAILS_ENV
 set :environment_variable, "RAILS_ENV"
-# Environment defaults to production
-set :environment, "production"
+# Environment defaults to the value of RAILS_ENV in the current environment if
+# it's set or production otherwise
+set :environment, ENV.fetch("RAILS_ENV", "production")
 # Path defaults to the directory `whenever` was run from
 set :path, Whenever.path
 

--- a/lib/whenever/version.rb
+++ b/lib/whenever/version.rb
@@ -1,3 +1,3 @@
 module Whenever
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/lib/whenever/version.rb
+++ b/lib/whenever/version.rb
@@ -1,3 +1,3 @@
 module Whenever
-  VERSION = '1.0.1'
+  VERSION = '1.0.0'
 end

--- a/test/functional/output_default_defined_jobs_test.rb
+++ b/test/functional/output_default_defined_jobs_test.rb
@@ -209,6 +209,20 @@ class OutputDefaultDefinedJobsTest < Whenever::TestCase
     assert_match two_hours + ' cd /some/other/path && RAILS_ENV=production bundle exec rake blahblah --silent', output
   end
 
+  test "A rake command that uses the default environment variable when RAILS_ENV is set" do
+    ENV.expects(:fetch).with("RAILS_ENV", "production").returns("development")
+    output = Whenever.cron \
+    <<-file
+      set :job_template, nil
+      set :path, '/my/path'
+      every 2.hours do
+        rake "blahblah"
+      end
+    file
+
+    assert_match two_hours + ' cd /my/path && RAILS_ENV=development bundle exec rake blahblah --silent', output
+  end
+
   test "A rake command that sets the environment variable" do
     output = Whenever.cron \
     <<-file


### PR DESCRIPTION
Fixes: https://github.com/javan/whenever/issues/660
Closes: https://github.com/javan/whenever/pull/796

All the hard work done by: @Haegin 

Set the environment for cron jobs based on the currently set RAILS_ENV environment variable. If RAILS_ENV is not
set it defaults to production