### PR TITLE
Fix respond to for job list

### DIFF
--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -37,7 +37,7 @@ module Whenever
       @set_variables.has_key?(name) ? @set_variables[name] : super
     end
 
-    def self.respond_to?(name, include_private = false)
+    def respond_to?(name, include_private = false)
       @set_variables.has_key?(name) || super
     end
 


### PR DESCRIPTION
I get the following error locally:

```
➜  app git:(upgrade-rails-and-ruby) ✗ rails c
Loading development environment (Rails 7.0.4)
irb(main):001:0> Rails.application.secrets.taxcloud[:api_key]/Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/whenever-1.0.0/lib/whenever/job_list.rb:41:in `respond_to?': undefined method `has_key?' for nil:NilClass (NoMethodError)

      @set_variables.has_key?(name) || super
                    ^^^^^^^^^
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/completion.rb:364:in `block in retrieve_completion_data'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/completion.rb:362:in `each_object'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/completion.rb:362:in `retrieve_completion_data'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/completion.rb:161:in `block in <module:InputCompletor>'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:1691:in `call_completion_proc_with_checking_args'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:545:in `call_completion_proc_with_checking_args'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:234:in `block in <class:Core>'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:590:in `instance_exec'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:590:in `call'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:625:in `call'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:672:in `render_each_dialog'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:653:in `block in render_dialog'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:652:in `each'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:652:in `render_dialog'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline/line_editor.rb:512:in `rerender'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:347:in `block (3 levels) in inner_readline'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:345:in `each'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:345:in `block (2 levels) in inner_readline'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:420:in `block in read_io'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:390:in `loop'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:390:in `read_io'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:343:in `block in inner_readline'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:341:in `loop'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:341:in `inner_readline'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/reline.rb:271:in `readmultiline'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/forwardable.rb:240:in `readmultiline'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/forwardable.rb:240:in `readmultiline'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/input-method.rb:422:in `gets'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:548:in `block (2 levels) in eval_input'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:777:in `signal_status'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:547:in `block in eval_input'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/ruby-lex.rb:283:in `lex'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/ruby-lex.rb:252:in `block (2 levels) in each_top_level_statement'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/ruby-lex.rb:249:in `loop'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/ruby-lex.rb:249:in `block in each_top_level_statement'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/ruby-lex.rb:248:in `catch'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb/ruby-lex.rb:248:in `each_top_level_statement'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:566:in `eval_input'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:500:in `block in run'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:499:in `catch'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:499:in `run'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/3.2.0/irb.rb:421:in `start'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/commands/console/console_command.rb:70:in `start'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/commands/console/console_command.rb:19:in `start'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/commands/console/console_command.rb:102:in `perform'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
	from /Users/ka8725/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:8:in `require'
	from bin/rails:8:in `<main>'
```

`@set_variables` is not initialize on class level. I think it's supposed to be defined on instance alongside the method_missing.