### PR TITLE
[CHORE] DX: easify getting started contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+## How to contribute to Whenever
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/your/whenever/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/your/whenever/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+
+#### **Do you have questions about the source code?**
+
+* Ask any question about how to use Whenever in the [whenever issues](https://github.com/javan/whenever/issues).
+
+#### **Do you want to contribute to the Whenever documentation?**
+
+Whenever is a volunteer effort. We encourage you to pitch in! 
+
+Thanks! :heart: :heart: :heart:
+
+Whenever Team
+
+---
+## Setup
+
+```bash
+$ bundle install
+```
+## Run tests
+
+```bash
+$ make test
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.DEFAULT_GOAL := test
+
+test:
+	bundle exec rake test
+.PHONY: test

--- a/whenever.gemspec
+++ b/whenever.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
-  s.add_development_dependency "mocha", ">= 0.9.5"
-  s.add_development_dependency "minitest"
+  s.add_development_dependency "mocha", ">= 0.9.5", "< 2.0.0"
+  s.add_development_dependency "minitest", "<= 5.2.0"
   s.add_development_dependency "appraisal"
 end


### PR DESCRIPTION
## WHY
In order attract developers to start contributing to the `whenever` gem, I believe we should improve developer experience and make the bootstrap for the repo easier.

## Changes 
- Creates `Makefile`
- Creates `CONTRIBUTING.md`
- Sets versioning for development dependencies `minitest` and `mocha` 
```diff
-  s.add_development_dependency "mocha", ">= 0.9.5"
-  s.add_development_dependency "minitest"
+  s.add_development_dependency "mocha", ">= 0.9.5", "< 2.0.0"
+  s.add_development_dependency "minitest", "<= 5.2.0"
```

## Related Issue
closes: https://github.com/javan/whenever/issues/845